### PR TITLE
pod: Support `runAsUser: 0`

### DIFF
--- a/vars/coreos.groovy
+++ b/vars/coreos.groovy
@@ -1,17 +1,22 @@
 // Run the passed body in a pod respecting some parameters.
 // Available parameters:
 //   image: string
-//   privileged: bool
 //   kvm: bool
+//   runAsUser: int
+//   privileged: bool (deprecated, equivalent to `runAsUser: 0`)
 def pod(params, body) {
     def podJSON = libraryResource 'com/github/coreos/pod.json'
     def podObj = readJSON text: podJSON
     podObj['spec']['containers'][1]['image'] = params['image']
 
     if (params['privileged']) {
+        // Backwards compat, see https://github.com/projectatomic/rpm-ostree/pull/1899/commits/9c1709c363e94760f0e9461719b92a7a4aca6c63#r323256575
+        params['runAsUser'] = 0
+    }
+    if (params['runAsUser']) {
         // XXX: tmp hack to get anyuid SCC; need to ask to get jenkins SA added
         podObj['spec']['serviceAccountName'] = "papr"
-        podObj['spec']['containers'][1]['securityContext'] = [runAsUser: 0]
+        podObj['spec']['containers'][1]['securityContext'] = [runAsUser: params['runAsUser']]
     }
 
     if (params['kvm']) {


### PR DESCRIPTION
I think this is better than calling it `privileged` as that
has a specific meaning in Docker/Kubernetes.

See my argument at https://lwn.net/Articles/796885/