### PR TITLE
pod: add support for memory requests

### DIFF
--- a/vars/coreos.groovy
+++ b/vars/coreos.groovy
@@ -4,6 +4,7 @@
 //   kvm: bool
 //   runAsUser: int
 //   privileged: bool (deprecated, equivalent to `runAsUser: 0`)
+//   memory: amount of RAM to request
 def pod(params, body) {
     def podJSON = libraryResource 'com/github/coreos/pod.json'
     def podObj = readJSON text: podJSON
@@ -21,6 +22,10 @@ def pod(params, body) {
 
     if (params['kvm']) {
         podObj['spec']['nodeSelector'] = [oci_kvm_hook: "allowed"]
+    }
+
+    if (params['memory']) {
+        podObj['spec']['containers'][1]['resources'] = [requests: [memory: params['memory']]]
     }
 
     // XXX: look into converting to a YAML string instead


### PR DESCRIPTION
E.g. in rpm-ostree CI, I'd like to be able to request 8G so we can stand
up a couple of VMs for testing.

Similarly, for coreos-assembler and fedora-coreos-config, I'd like to
run kola tests in parallel.