### PR TITLE
coreos.groovy: drop defaultContainer field

### DIFF
--- a/vars/coreos.groovy
+++ b/vars/coreos.groovy
@@ -50,7 +50,7 @@ def pod(params, body) {
         podYAML = readFile(file: "${label}.yaml")
     }
 
-    podTemplate(cloud: 'openshift', yaml: podYAML, label: label, defaultContainer: 'jnlp') {
+    podTemplate(cloud: 'openshift', yaml: podYAML, label: label) {
         node(label) { container('worker') {
             body.call()
         }}


### PR DESCRIPTION
This causes an unknown parameter warning:

    WARNING: Unknown parameter(s) found for class type
    'org.csanchez.jenkins.plugins.kubernetes.pipeline.PodTemplateStep':
    defaultContainer