### PR TITLE
coreos.groovy: always mount emptyDir on /srv

### DIFF
--- a/vars/coreos.groovy
+++ b/vars/coreos.groovy
@@ -33,13 +33,19 @@ def pod(params, body) {
     if (params['cpu']) {
         podObj['spec']['containers'][1]['resources']['requests']['cpu'] = params['cpu'].toString()
     }
-    if (params['emptyDirs']) {
-        podObj['spec']['volumes'] = []
-        podObj['spec']['containers'][1]['volumeMounts'] = []
-        params['emptyDirs'].eachWithIndex { mountPath, i ->
-            podObj['spec']['volumes'] += ['name': "emptydir-${i}".toString(), 'emptyDir': [:]]
-            podObj['spec']['containers'][1]['volumeMounts'] += ['name': "emptydir-${i}".toString(), 'mountPath': mountPath]
-        }
+
+    if (!params['emptyDirs']) {
+        params['emptyDirs'] = []
+    }
+
+    // for now, we always mount an emptyDir on /srv
+    params['emptyDirs'] += '/srv/'
+
+    podObj['spec']['volumes'] = []
+    podObj['spec']['containers'][1]['volumeMounts'] = []
+    params['emptyDirs'].eachWithIndex { mountPath, i ->
+        podObj['spec']['volumes'] += ['name': "emptydir-${i}".toString(), 'emptyDir': [:]]
+        podObj['spec']['containers'][1]['volumeMounts'] += ['name': "emptydir-${i}".toString(), 'mountPath': mountPath]
     }
 
     // XXX: look into converting to a YAML string instead


### PR DESCRIPTION
Let's designate `/srv` as the place where CI work that needs a real
filesystem and does lots of IO can operate.