### PR TITLE
coreos.groovy: add tmp hack to avoid papr SA on CoreOS CI

### DIFF
--- a/vars/coreos.groovy
+++ b/vars/coreos.groovy
@@ -17,8 +17,10 @@ def pod(params, body) {
         params['runAsUser'] = 0
     }
     if (params['runAsUser'] != null) {
-        // XXX: tmp hack to get anyuid SCC; need to ask to get jenkins SA added
-        podObj['spec']['serviceAccountName'] = "papr"
+        // XXX: hack for the old projectatomic-ci namespace. coreos-ci's jenkins has anyuid already
+        if (params['coreosci'] == null || params['coreosci'] == false) {
+            podObj['spec']['serviceAccountName'] = "papr"
+        }
         podObj['spec']['containers'][1]['securityContext'] = [runAsUser: params['runAsUser']]
     }
 


### PR DESCRIPTION
We'll be able to drop this entirely once we've moved over to CoreOS CI.
But until then, let's require code running on CoreOS CI to pass
`coreosci: true` and key off of that to determine if to use the papr
SA.

I wanted to base this off of the `JENKINS_URL` environment variable at
first, but I couldn't get it to work.