### PR TITLE
Add more custom steps, streamline cosa build + kola workflow

### DIFF
--- a/vars/cosaPod.groovy
+++ b/vars/cosaPod.groovy
@@ -1,0 +1,15 @@
+// Thin wrapper around pod() which auto-selects images and kvm.
+// Additional available parameters:
+//   image: string
+//   buildroot: bool
+def call(params = [:], Closure body) {
+    if (params['image'] == null) {
+        if (params['buildroot']) {
+            params['image'] = 'registry.svc.ci.openshift.org/coreos/cosa-buildroot:latest'
+        } else {
+            params['image'] = 'quay.io/coreos-assembler/coreos-assembler:latest'
+        }
+    }
+
+    pod(params, body)
+}

--- a/vars/fcosBuild.groovy
+++ b/vars/fcosBuild.groovy
@@ -1,0 +1,36 @@
+// Build FCOS, possibly with modifications.
+// Available parameters:
+//    make:         boolean -- run `make && make install DESTDIR=...`
+//    makeDirs:   []string  -- extra list of directories from which to `make && make install DESTDIR=...`
+//    skipKola:     boolean -- don't automatically run kola on resulting build
+//    overlays:   []string  -- list of directories to overlay
+def call(params = [:]) {
+    stage("Build FCOS") {
+        shwrap("""
+        mkdir /srv/fcos && cd /srv/fcos
+        cosa init https://github.com/coreos/fedora-coreos-config
+        """)
+
+        if (params['make']) {
+            shwrap("make && make install DESTDIR=/srv/fcos/overrides/rootfs")
+        }
+        if (params['makeDirs']) {
+            params['makeDirs'].each{
+                shwrap("make -C ${it} && make -C ${it} install DESTDIR=/srv/fcos/overrides/rootfs")
+            }
+        }
+
+        if (params['overlays']) {
+            params['overlays'].each{
+                shwrap("rsync -av ${it}/ /srv/fcos/overrides/rootfs")
+            }
+        }
+
+        shwrap("cd /srv/fcos && cosa build")
+    }
+
+    if (!params['skipKola']) {
+        fcosKola()
+    }
+}
+

--- a/vars/fcosKola.groovy
+++ b/vars/fcosKola.groovy
@@ -1,0 +1,14 @@
+// Run kola tests on the latest build in the cosa dir
+def call(cosaDir = "/srv/fcos") {
+    stage("Kola") {
+        try {
+            shwrap("cd ${cosaDir} && cosa kola run --parallel 8")
+        } finally {
+            shwrap("tar -c -C ${cosaDir}/tmp kola | xz -c9 > ${env.WORKSPACE}/kola.tar.xz")
+            archiveArtifacts allowEmptyArchive: true, artifacts: 'kola.tar.xz'
+        }
+        // sanity check kola actually ran and dumped its output in tmp/
+        shwrap("test -d ${cosaDir}/tmp/kola")
+    }
+}
+

--- a/vars/pod.groovy
+++ b/vars/pod.groovy
@@ -3,22 +3,15 @@
 //   image: string
 //   kvm: bool
 //   runAsUser: int
-//   privileged: bool (deprecated, equivalent to `runAsUser: 0`)
 //   memory: amount of RAM to request
 //   cpu: amount of CPU to request
 //   emptyDirs: []string
-def pod(params, body) {
+def call(params = [:], Closure body) {
     def podJSON = libraryResource 'com/github/coreos/pod.json'
     def podObj = readJSON text: podJSON
     podObj['spec']['containers'][1]['image'] = params['image']
 
-    if (params['privileged']) {
-        // Backwards compat, see https://github.com/projectatomic/rpm-ostree/pull/1899/commits/9c1709c363e94760f0e9461719b92a7a4aca6c63#r323256575
-        params['runAsUser'] = 0
-    }
     if (params['runAsUser'] != null) {
-        // XXX: tmp hack to get anyuid SCC; need to ask to get jenkins SA added
-        podObj['spec']['serviceAccountName'] = "papr"
         podObj['spec']['containers'][1]['securityContext'] = [runAsUser: params['runAsUser']]
     }
 
@@ -58,14 +51,7 @@ def pod(params, body) {
 
     podTemplate(cloud: 'openshift', yaml: podYAML, label: label) {
         node(label) { container('worker') {
-            body.call()
+            body()
         }}
     }
-}
-
-def shwrap(cmds) {
-    sh """
-        set -xeuo pipefail
-        ${cmds}
-    """
 }

--- a/vars/shwrap.groovy
+++ b/vars/shwrap.groovy
@@ -1,0 +1,6 @@
+def call(cmds) {
+    sh """
+        set -xeuo pipefail
+        ${cmds}
+    """
+}


### PR DESCRIPTION
This changes in significant ways how this shared library is set up.
First, I re-read the documentation on shared libraries more closely and
we now follow conventions like having custom steps use a `call()`
function.

But also, there is now a much bigger emphasis on the `cosa build`
workflow. For example, there is now a `cosaPod` which default to the
cosa image.

There's a `buildroot` parameter one can use to request the buildroot
image instead (and of course, there's a lower-level `pod` step for full
control).

There is also a `fcosBuild` custom step, which will automatically build
FCOS, optionally building and/or layering some directories, then run
`cosa kola`.