### PR TITLE
fcosKola: also run upgrade tests by default

### DIFF
--- a/vars/fcosKola.groovy
+++ b/vars/fcosKola.groovy
@@ -1,14 +1,29 @@
 // Run kola tests on the latest build in the cosa dir
 def call(cosaDir = "/srv/fcos") {
-    stage("Kola") {
-        try {
-            shwrap("cd ${cosaDir} && cosa kola run --parallel 8")
-        } finally {
-            shwrap("tar -c -C ${cosaDir}/tmp kola | xz -c9 > ${env.WORKSPACE}/kola.tar.xz")
-            archiveArtifacts allowEmptyArchive: true, artifacts: 'kola.tar.xz'
+    stage('Kola') {
+        parallel run: {
+            stage("run") {
+                try {
+                    shwrap("cd ${cosaDir} && cosa kola run --parallel 8")
+                } finally {
+                    shwrap("tar -c -C ${cosaDir}/tmp kola | xz -c9 > ${env.WORKSPACE}/kola.tar.xz")
+                    archiveArtifacts allowEmptyArchive: true, artifacts: 'kola.tar.xz'
+                }
+                // sanity check kola actually ran and dumped its output in tmp/
+                shwrap("test -d ${cosaDir}/tmp/kola")
+            }
+        },
+        run_upgrades: {
+            stage("run-upgrade") {
+                try {
+                    shwrap("cd ${cosaDir} && cosa kola --upgrades")
+                } finally {
+                    shwrap("tar -c -C ${cosaDir}/tmp kola-upgrade | xz -c9 > ${env.WORKSPACE}/kola-upgrade.tar.xz")
+                    archiveArtifacts allowEmptyArchive: true, artifacts: 'kola-upgrade.tar.xz'
+                }
+                // sanity check kola actually ran and dumped its output in tmp/
+                shwrap("test -d ${cosaDir}/tmp/kola-upgrade")
+            }
         }
-        // sanity check kola actually ran and dumped its output in tmp/
-        shwrap("test -d ${cosaDir}/tmp/kola")
     }
 }
-


### PR DESCRIPTION
No reason not to do this always especially since we basically get it for
free timewise (we run it in parallel to the main run, which normally
takes longer anyway).