### PR TITLE
ci: hook up to CoreOS CI

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -1,0 +1,9 @@
+// Documentation: https://github.com/coreos/coreos-ci/blob/master/README-upstream-ci.md
+
+library "github.com/coreos/coreos-ci-lib@pull/${env.CHANGE_ID}/merge"
+
+cosaPod(buildroot: true) {
+    checkout scm
+
+    fcosBuild()
+}


### PR DESCRIPTION
And of course, we should test our test scripts themselves. So hook this
repo up to CoreOS CI.