### PR TITLE
Add shwrapRc helper function

### DIFF
--- a/vars/shwrapRc.groovy
+++ b/vars/shwrapRc.groovy
@@ -1,0 +1,6 @@
+def call(cmds) {
+    return sh(returnStatus: true, script: """
+        set -xeuo pipefail
+        ${cmds}
+    """)
+}


### PR DESCRIPTION
So you can do things like `test -s foobar` more easily.
Upstreamed from fedora-coreos-pipeline.