### PR TITLE
fcosKola: allow skipping upgrade tests

### DIFF
--- a/vars/fcosKola.groovy
+++ b/vars/fcosKola.groovy
@@ -1,30 +1,44 @@
 // Run kola tests on the latest build in the cosa dir
-def call(cosaDir = "/srv/fcos") {
-    stage('Kola') {
-        parallel run: {
-            stage("run") {
-                def args = ""
-                // Add the tests/kola directory, but only if it's not the same as the
-                // src/config repo which is also automatically added.
-                if (shwrapRc("""
-                    test -d tests/kola
-                    configorigin=\$(cd ${cosaDir}/src/config & git config --get remote.origin.url)
-                    gitorigin=\$(cd ${env.WORKSPACE} && git config --get remote.origin.url)
-                    test "\$configorigin" != "\$gitorigin"
-                """) == 0) {
-                    args += "--exttest ${env.WORKSPACE}"
-                }
-                try {
-                    shwrap("cd ${cosaDir} && cosa kola run --parallel 8 ${args}")
-                } finally {
-                    shwrap("tar -c -C ${cosaDir}/tmp kola | xz -c9 > ${env.WORKSPACE}/kola.tar.xz")
-                    archiveArtifacts allowEmptyArchive: true, artifacts: 'kola.tar.xz'
-                }
-                // sanity check kola actually ran and dumped its output in tmp/
-                shwrap("test -d ${cosaDir}/tmp/kola")
+// Available parameters:
+//    cosaDir:         string  -- cosa working directory
+//    skipUpgrade:     boolean -- skip running `cosa kola --upgrades`
+def call(params = [:]) {
+    def cosaDir = "/srv/fcos"
+    if (params['cosaDir']) {
+        cosaDir = params['cosaDir']
+    }
+
+    // This is a bit obscure; what we're doing here is building a map of "name"
+    // to "closure" which `parallel` will run in parallel. That way, we can
+    // conditionally only add the `run_upgrades` stage if not explicitly
+    // skipped.
+    kolaRuns = [:]
+    kolaRuns["run"] = {
+        stage("run") {
+            def args = ""
+            // Add the tests/kola directory, but only if it's not the same as the
+            // src/config repo which is also automatically added.
+            if (shwrapRc("""
+                test -d tests/kola
+                configorigin=\$(cd ${cosaDir}/src/config & git config --get remote.origin.url)
+                gitorigin=\$(cd ${env.WORKSPACE} && git config --get remote.origin.url)
+                test "\$configorigin" != "\$gitorigin"
+            """) == 0)
+            {
+                args += "--exttest ${env.WORKSPACE}"
             }
-        },
-        run_upgrades: {
+            try {
+                shwrap("cd ${cosaDir} && cosa kola run --parallel 8 ${args}")
+            } finally {
+                shwrap("tar -c -C ${cosaDir}/tmp kola | xz -c9 > ${env.WORKSPACE}/kola.tar.xz")
+                archiveArtifacts allowEmptyArchive: true, artifacts: 'kola.tar.xz'
+            }
+            // sanity check kola actually ran and dumped its output in tmp/
+            shwrap("test -d ${cosaDir}/tmp/kola")
+        }
+    }
+    if (!params["skipUpgrade"]) {
+        kolaRuns['run_upgrades'] = {
             stage("run-upgrade") {
                 try {
                     shwrap("cd ${cosaDir} && cosa kola --upgrades")
@@ -36,5 +50,9 @@ def call(cosaDir = "/srv/fcos") {
                 shwrap("test -d ${cosaDir}/tmp/kola-upgrade")
             }
         }
+    }
+
+    stage('Kola') {
+        parallel(kolaRuns)
     }
 }


### PR DESCRIPTION
In `next-devel` right now, we don't have a previous build yet, so
`run-upgrade` doesn't know what parent build to use. There's a good
argument here that we could use the `testing-devel` stream as the
starting stream for now (and actually, that's something that we should
enhance our CI to cover anyway, even when we *do* have `next-devel`
parent builds, since that mimics what nodes will eventually do).

But I just want to get `next-devel` off the ground for now. The first
step either way is allowing us to skip upgrade testing here so that we
can run it manually with more options as needed.