### PR TITLE
fcosBuild: use `cosa build --strict`

### DIFF
--- a/vars/fcosBuild.groovy
+++ b/vars/fcosBuild.groovy
@@ -28,7 +28,7 @@ def call(params = [:]) {
             }
         }
 
-        shwrap("cd /srv/fcos && cosa build")
+        shwrap("cd /srv/fcos && cosa build --strict")
     }
 
     if (!params['skipKola']) {


### PR DESCRIPTION
We always want to build in strict mode for CI. See:
https://github.com/coreos/fedora-coreos-tracker/issues/454