### PR TITLE
fcosBuild: do a fetch first

### DIFF
--- a/vars/fcosBuild.groovy
+++ b/vars/fcosBuild.groovy
@@ -28,6 +28,7 @@ def call(params = [:]) {
             }
         }
 
+        shwrap("cd /srv/fcos && cosa fetch --strict")
         shwrap("cd /srv/fcos && cosa build --strict")
     }
 


### PR DESCRIPTION
Doing `cosa build` directly without fetching normally works, though that
broke recently. Let's just do an explicit `fetch` for now.

See also https://github.com/coreos/coreos-assembler/pull/1379.