### PR TITLE
cosaPod: write out details about cosa version

### DIFF
--- a/vars/cosaPod.groovy
+++ b/vars/cosaPod.groovy
@@ -16,5 +16,8 @@ def call(params = [:], Closure body) {
         params['kvm'] = true
     }
 
-    pod(params, body)
+    pod(params) {
+        shwrap("cat /cosa/coreos-assembler-git.json || :")
+        body()
+    }
 }


### PR DESCRIPTION
I had done this temporarily in the `.cci.jenkinsfile` of Ignition in
https://github.com/coreos/ignition/pull/976 to help debugging and I
found it really useful.

Let's just always write it out. But don't error out if it somehow
doesn't exist.