### PR TITLE
shwrap: set HOME to WORKSPACE

### DIFF
--- a/vars/shwrap.groovy
+++ b/vars/shwrap.groovy
@@ -1,6 +1,9 @@
 def call(cmds) {
-    sh """
-        set -xeuo pipefail
-        ${cmds}
-    """
+    // default is HOME=/ which normally we don't have access to
+    withEnv(["HOME=${env.WORKSPACE}"]) {
+        sh """
+            set -xeuo pipefail
+            ${cmds}
+        """
+    }
 }


### PR DESCRIPTION
Normally, we're running unprivileged and so Jenkins' setting of `HOME=/`
is not really helpful when running apps like `cargo` and `go build`
which expect to be able to cache things in the homedir.

If for whatever reason someone does want the default `HOME=/` behaviour,
they can just use the less opinionated `sh` step.