### PR TITLE
pod: bump timeout from jnlp to 300s

### DIFF
--- a/vars/pod.groovy
+++ b/vars/pod.groovy
@@ -49,7 +49,7 @@ def call(params = [:], Closure body) {
         podYAML = readFile(file: "${label}.yaml")
     }
 
-    podTemplate(cloud: 'openshift', yaml: podYAML, label: label) {
+    podTemplate(cloud: 'openshift', yaml: podYAML, label: label, slaveConnectTimeout: 300) {
         node(label) { container('worker') {
             body()
         }}


### PR DESCRIPTION
The default is 100s, which is too short if the cluster is under load and
e.g. the image takes time to download, etc...