### PR TITLE
pod: drop hardcoded jnlp container

### DIFF
--- a/resources/com/github/coreos/pod.json
+++ b/resources/com/github/coreos/pod.json
@@ -4,14 +4,6 @@
     "spec": {
         "containers": [
             {
-                "name": "jnlp",
-                "image": "jenkins-slave-base-centos7:latest",
-                "args": [
-                    "$(JENKINS_SECRET)",
-                    "$(JENKINS_NAME)"
-                ]
-            },
-            {
                 "name": "worker",
                 "imagePullPolicy": "Always",
                 "command": [

--- a/vars/pod.groovy
+++ b/vars/pod.groovy
@@ -9,22 +9,22 @@
 def call(params = [:], Closure body) {
     def podJSON = libraryResource 'com/github/coreos/pod.json'
     def podObj = readJSON text: podJSON
-    podObj['spec']['containers'][1]['image'] = params['image']
+    podObj['spec']['containers'][0]['image'] = params['image']
 
     if (params['runAsUser'] != null) {
-        podObj['spec']['containers'][1]['securityContext'] = [runAsUser: params['runAsUser']]
+        podObj['spec']['containers'][0]['securityContext'] = [runAsUser: params['runAsUser']]
     }
 
-    podObj['spec']['containers'][1]['resources'] = [requests: [:], limits: [:]]
+    podObj['spec']['containers'][0]['resources'] = [requests: [:], limits: [:]]
     if (params['memory']) {
-        podObj['spec']['containers'][1]['resources']['requests']['memory'] = params['memory'].toString()
+        podObj['spec']['containers'][0]['resources']['requests']['memory'] = params['memory'].toString()
     }
     if (params['cpu']) {
-        podObj['spec']['containers'][1]['resources']['requests']['cpu'] = params['cpu'].toString()
+        podObj['spec']['containers'][0]['resources']['requests']['cpu'] = params['cpu'].toString()
     }
     if (params['kvm']) {
-        podObj['spec']['containers'][1]['resources']['requests']['devices.kubevirt.io/kvm'] = "1"
-        podObj['spec']['containers'][1]['resources']['limits']['devices.kubevirt.io/kvm'] = "1"
+        podObj['spec']['containers'][0]['resources']['requests']['devices.kubevirt.io/kvm'] = "1"
+        podObj['spec']['containers'][0]['resources']['limits']['devices.kubevirt.io/kvm'] = "1"
     }
 
     if (!params['emptyDirs']) {
@@ -35,10 +35,10 @@ def call(params = [:], Closure body) {
     params['emptyDirs'] += '/srv/'
 
     podObj['spec']['volumes'] = []
-    podObj['spec']['containers'][1]['volumeMounts'] = []
+    podObj['spec']['containers'][0]['volumeMounts'] = []
     params['emptyDirs'].eachWithIndex { mountPath, i ->
         podObj['spec']['volumes'] += ['name': "emptydir-${i}".toString(), 'emptyDir': [:]]
-        podObj['spec']['containers'][1]['volumeMounts'] += ['name': "emptydir-${i}".toString(), 'mountPath': mountPath]
+        podObj['spec']['containers'][0]['volumeMounts'] += ['name': "emptydir-${i}".toString(), 'mountPath': mountPath]
     }
 
     // XXX: look into converting to a YAML string instead


### PR DESCRIPTION
Instead, let the Kubernetes Jenkins plugin inject the default jnlp
container to use so that we're sure it's always using one that's made
for the given k8s version and plugin version.

This is causing issues on the new cluster where the `sh` step would
hang. It seems to be related to running on new k8s but old Jenkins, and
some kind of conflict with how working directories have changed. For
more details, see:

https://issues.jenkins-ci.org/browse/JENKINS-58777
https://issues.jenkins-ci.org/browse/JENKINS-58766