### PR TITLE
cosaPod: spawn container with dumb-init

### DIFF
--- a/vars/cosaPod.groovy
+++ b/vars/cosaPod.groovy
@@ -16,6 +16,9 @@ def call(params = [:], Closure body) {
         params['kvm'] = true
     }
 
+    // we don't like zombies
+    params['cmd'] = ["/usr/bin/dumb-init", "/usr/bin/sleep", "infinity"]
+
     pod(params) {
         shwrap("cat /cosa/coreos-assembler-git.json || :")
         body()

--- a/vars/pod.groovy
+++ b/vars/pod.groovy
@@ -6,6 +6,7 @@
 //   memory: amount of RAM to request
 //   cpu: amount of CPU to request
 //   emptyDirs: []string
+//   cmd: []string
 def call(params = [:], Closure body) {
     def podJSON = libraryResource 'com/github/coreos/pod.json'
     def podObj = readJSON text: podJSON
@@ -29,6 +30,10 @@ def call(params = [:], Closure body) {
 
     if (!params['emptyDirs']) {
         params['emptyDirs'] = []
+    }
+
+    if (params['cmd']) {
+        podObj['spec']['containers'][0]['command'] = params['cmd']
     }
 
     // for now, we always mount an emptyDir on /srv


### PR DESCRIPTION
Let's use `dumb-init` by default for cosa pods so that we don't end up
with a swarm of zombies taking up resources.

I have a feeling this might also be contributing to the ulimit
exhaustion we're seeing in CI after the move to the new OCP 4.4 cluster.

See also https://github.com/kubernetes/kubernetes/issues/84210.