### PR TITLE
shwrap: Fix umask if it's not set

### DIFF
--- a/vars/shwrap.groovy
+++ b/vars/shwrap.groovy
@@ -1,8 +1,12 @@
 def call(cmds) {
-    // default is HOME=/ which normally we don't have access to
+    // default is HOME=/ which normally we don't have access to.
+    // Also if umask is somehow unset, fix it.
     withEnv(["HOME=${env.WORKSPACE}"]) {
         sh """
             set -xeuo pipefail
+            if [ `umask` = 0000 ]; then
+              umask 0022
+            fi
             ${cmds}
         """
     }


### PR DESCRIPTION
We never want a 0 umask; it can e.g. cause world writable directories
which triggers failures in e.g. ostree's CI tests.