### PR TITLE
Add shwrapCapture() step

### DIFF
--- a/vars/shwrapCapture.groovy
+++ b/vars/shwrapCapture.groovy
@@ -1,0 +1,6 @@
+def call(cmds) {
+    return sh(returnStdout: true, script: """
+        set -euo pipefail
+        ${cmds}
+    """).trim()
+}


### PR DESCRIPTION
This is a variant on shwrap() which returns the output of the command.
Part of draining helper functions from the pipeline into the library in
prep for modeling the pipeline jobs after upstream CI.