### PR TITLE
Revert "Revert "shwrap: Fix umask if it's not set""

### DIFF
--- a/vars/shwrap.groovy
+++ b/vars/shwrap.groovy
@@ -1,8 +1,12 @@
 def call(cmds) {
-    // default is HOME=/ which normally we don't have access to
+    // default is HOME=/ which normally we don't have access to.
+    // Also if umask is somehow unset, fix it.
     withEnv(["HOME=${env.WORKSPACE}"]) {
         sh """
             set -xeuo pipefail
+            if [ `umask` = 0000 ]; then
+              umask 0022
+            fi
             ${cmds}
         """
     }


### PR DESCRIPTION
This reverts commit b8e563b1642dbdc10d5669e4c906a58e22dfbc3f.

Looks like we're hitting this again, so let's add it as a short-term
workaround.