### PR TITLE
Add checkoutToDir helper step

### DIFF
--- a/vars/checkoutToDir.groovy
+++ b/vars/checkoutToDir.groovy
@@ -1,0 +1,9 @@
+def call(scm, dir) {
+    // https://support.cloudbees.com/hc/en-us/articles/226122247-How-to-customize-Checkout-for-Pipeline-Multibranch
+    checkout([
+         $class: 'GitSCM',
+         branches: scm.branches,
+         extensions: scm.extensions + [[$class: 'RelativeTargetDirectory', relativeTargetDir: dir]],
+         userRemoteConfigs: scm.userRemoteConfigs
+    ])
+}


### PR DESCRIPTION
This is a thin wrapper around `checkout` which makes it easy to check
out the repo into a subdirectory instead of directly into the workspace.

This can be useful especially in the context of kola external tests,
which use the directory name as part of the test name and you'd prefer a
short predictable name rather than Jenkins' long workspace name.