### PR TITLE
fcosBuild: Add `cosaDir`parameter and getCosaDir

### DIFF
--- a/vars/utils.groovy
+++ b/vars/utils.groovy
@@ -1,0 +1,7 @@
+def getCosaDir(params = [:]) {
+    if (params['cosaDir']) {
+        return params['cosaDir']
+    } else {
+        return "/srv/fcos"
+    }
+}


### PR DESCRIPTION
- Add `cosaDir` parameter to be used across multiples CIs
making it usefull to change cosa working directory
- Add getCosaDir in utils as a place with common
functions used in CI

Signed-off-by: Renata Ravanelli <rravanel@redhat.com>