### PR TITLE
fcosKola: don't nest branches in "stage"

### DIFF
--- a/vars/fcosKola.groovy
+++ b/vars/fcosKola.groovy
@@ -20,46 +20,42 @@ def call(params = [:]) {
     // skipped.
     kolaRuns = [:]
     kolaRuns["run"] = {
-        stage("run") {
-            def args = ""
-            // Add the tests/kola directory, but only if it's not the same as the
-            // src/config repo which is also automatically added.
-            if (shwrapRc("""
-                test -d ${env.WORKSPACE}/tests/kola
-                configorigin=\$(cd ${cosaDir}/src/config && git config --get remote.origin.url)
-                gitorigin=\$(cd ${env.WORKSPACE} && git config --get remote.origin.url)
-                test "\$configorigin" != "\$gitorigin"
-            """) == 0)
-            {
-                args += "--exttest ${env.WORKSPACE}"
-            }
-            def parallel = params.get('parallel', 8);
-            def extraArgs = params.get('extraArgs', "");
-            try {
-                if (params['basicScenarios']) {
-                    shwrap("cd ${cosaDir} && cosa kola run --basic-qemu-scenarios")
-                }
-                shwrap("cd ${cosaDir} && cosa kola run --build ${buildID} ${platformArgs} --parallel ${parallel} ${args} ${extraArgs}")
-            } finally {
-                shwrap("tar -c -C ${cosaDir}/tmp kola | xz -c9 > ${env.WORKSPACE}/kola.tar.xz")
-                archiveArtifacts allowEmptyArchive: true, artifacts: 'kola.tar.xz'
-            }
-            // sanity check kola actually ran and dumped its output in tmp/
-            shwrap("test -d ${cosaDir}/tmp/kola")
+        def args = ""
+        // Add the tests/kola directory, but only if it's not the same as the
+        // src/config repo which is also automatically added.
+        if (shwrapRc("""
+            test -d ${env.WORKSPACE}/tests/kola
+            configorigin=\$(cd ${cosaDir}/src/config && git config --get remote.origin.url)
+            gitorigin=\$(cd ${env.WORKSPACE} && git config --get remote.origin.url)
+            test "\$configorigin" != "\$gitorigin"
+        """) == 0)
+        {
+            args += "--exttest ${env.WORKSPACE}"
         }
+        def parallel = params.get('parallel', 8);
+        def extraArgs = params.get('extraArgs', "");
+        try {
+            if (params['basicScenarios']) {
+                shwrap("cd ${cosaDir} && cosa kola run --basic-qemu-scenarios")
+            }
+            shwrap("cd ${cosaDir} && cosa kola run --build ${buildID} ${platformArgs} --parallel ${parallel} ${args} ${extraArgs}")
+        } finally {
+            shwrap("tar -c -C ${cosaDir}/tmp kola | xz -c9 > ${env.WORKSPACE}/kola.tar.xz")
+            archiveArtifacts allowEmptyArchive: true, artifacts: 'kola.tar.xz'
+        }
+        // sanity check kola actually ran and dumped its output in tmp/
+        shwrap("test -d ${cosaDir}/tmp/kola")
     }
     if (!params["skipUpgrade"]) {
         kolaRuns['run_upgrades'] = {
-            stage("run-upgrade") {
-                try {
-                    shwrap("cd ${cosaDir} && cosa kola --upgrades --build ${buildID} ${platformArgs}")
-                } finally {
-                    shwrap("tar -c -C ${cosaDir}/tmp kola-upgrade | xz -c9 > ${env.WORKSPACE}/kola-upgrade.tar.xz")
-                    archiveArtifacts allowEmptyArchive: true, artifacts: 'kola-upgrade.tar.xz'
-                }
-                // sanity check kola actually ran and dumped its output in tmp/
-                shwrap("test -d ${cosaDir}/tmp/kola-upgrade")
+            try {
+                shwrap("cd ${cosaDir} && cosa kola --upgrades --build ${buildID} ${platformArgs}")
+            } finally {
+                shwrap("tar -c -C ${cosaDir}/tmp kola-upgrade | xz -c9 > ${env.WORKSPACE}/kola-upgrade.tar.xz")
+                archiveArtifacts allowEmptyArchive: true, artifacts: 'kola-upgrade.tar.xz'
             }
+            // sanity check kola actually ran and dumped its output in tmp/
+            shwrap("test -d ${cosaDir}/tmp/kola-upgrade")
         }
     }
 


### PR DESCRIPTION
These stage labels aren't actually getting rendered. Instead, the branch
name is used, which is good enough. So let's simplify this.