### PR TITLE
fcosBuild: default to forcing a build

### DIFF
--- a/vars/fcosBuild.groovy
+++ b/vars/fcosBuild.groovy
@@ -8,6 +8,7 @@
 //    extraFetchArgs: string  -- extra arguments to pass to `cosa fetch`
 //    extraArgs:      string  -- extra arguments to pass to `cosa build`
 //    cosaDir:        string  -- cosa working directory
+//    noForce:        boolean -- don't force a cosa build even if nothing changed
 def call(params = [:]) {
     stage("Build FCOS") {
         def cosaDir = utils.getCosaDir(params)
@@ -36,6 +37,9 @@ def call(params = [:]) {
         shwrap("cd ${cosaDir} && cosa fetch --strict ${extraFetchArgs}")
 
         def extraArgs = params.get('extraArgs', "");
+        if (!params['noForce']) {
+            extraArgs = "--force ${extraArgs}"
+        }
         shwrap("cd ${cosaDir} && cosa build --strict ${extraArgs}")
     }
 


### PR DESCRIPTION
Right now, upstream CI runs might not build the OSTree if nothing
actually changed since the last pipeline build we `buildprep` from (this
can happen pretty easily today because of a bug in rpm-ostree which
causes us to not include the overlays in the state checksum:
https://github.com/coreos/rpm-ostree/pull/2310).

We could try to detect this and e.g. fetch the artifacts from the
previous build, but for CI runs, we really want to always build from
scratch anyway to be safe and make it more deterministic.

Noticed this while reviewing
https://github.com/coreos/fedora-coreos-config/pull/731 whose `cosa
build` command currently outputs:

```
No apparent changes since previous commit; use --force-nocache to override
commit: 104cb15f0154ffad59e320ef491d9b4f60de30e56ab601279fc9e30a36b01999 image: 852f4012f93211fc00b8d4c14d7554bec3490a2031eb9cae3a6d7c5ffd42c893
No changes in image inputs.
Config commit: fa64b95fce5bf7174485d07d567c9cb62dcad9e0
Using manifest: /srv/fcos/src/config/manifest.yaml
qemu image already exists:
fedora-coreos-33.20201112.20.0-qemu.x86_64.qcow2.xz
...
--- FAIL: fcos.filesystem (0.00s)
        harness.go:959: Cluster failed starting machines: lstat /srv/fcos/builds/33.20201112.20.0/x86_64/fedora-coreos-33.20201112.20.0-qemu.x86_64.qcow2.xz: no such file or directory
```

(`cosa build` detects no changes because of the rpm-ostree bug, and
`cosa buildextend-qemu` sees the QEMU image in `meta.json` even though
we don't have it locally, and so `kola` fails.)