### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @jlebon @ravanelli @mike-nguyen @darkmuggle @bh7cw


### PR DESCRIPTION
Code owners specified in this file are automatically requested to
review when someone opens a pull request that modified code they
own.  Currently the code owners are globally set for the repo but
can be changed to per language extension or per subdirectory, etc.