### PR TITLE
Add buildImage

### DIFF
--- a/resources/com/github/coreos/buildconfig.json
+++ b/resources/com/github/coreos/buildconfig.json
@@ -1,0 +1,101 @@
+{
+  "kind":"Template",
+  "apiVersion":"v1",
+  "metadata":{
+    "name":"${NAME}"
+  },
+  "labels":{
+    "template":"${NAME}",
+    "app":"${NAME}"
+  },
+  "objects":[
+    {
+      "kind":"ImageStream",
+      "apiVersion":"v1",
+      "metadata":{
+        "name":"${NAME}",
+        "ownerReferences":[
+          {
+            "apiVersion":"batch/v1",
+            "kind":"Job",
+            "name":"${OWNERNAME}",
+            "uid":"${UID}",
+            "controller":true
+          }
+        ]
+      },
+      "spec":{
+        "failedBuildHistoryLimit":1,
+        "successfulBuildsHistoryLimit":1,
+        "lookupPolicy":{
+          "local":true
+        }
+      }
+    },
+    {
+      "kind":"BuildConfig",
+      "apiVersion":"v1",
+      "metadata":{
+        "name":"${NAME}",
+        "ownerReferences":[
+          {
+            "apiVersion":"batch/v1",
+            "kind":"Job",
+            "name":"${OWNERNAME}",
+            "uid":"${UID}",
+            "controller":true
+          }
+        ]
+      },
+      "spec":{
+        "source":{
+          "type":"Git",
+          "git":{
+            "uri":"none",
+            "ref":"none"
+          }
+	},
+        "strategy":{
+          "dockerStrategy":{
+            "dockerfilePath":"${DOCKERFILE}"
+          },
+          "dockerfilePath":"${DOCKERFILE}"
+        },
+        "output":{
+          "to":{
+            "kind":"ImageStreamTag",
+            "name":"${NAME}:latest",
+            "namespace":"coreos-ci"
+          }
+        }
+      }
+    }
+  ],
+  "parameters":[
+    {
+      "name":"NAME",
+      "displayName":"Name",
+      "description":"The name assigned to all of the frontend objects defined in this template.",
+      "required":true,
+      "value":"none"
+    },
+    {
+      "name":"DOCKERFILE",
+      "displayName":"Docker File",
+      "description":"The Docker file that will be use to build the application",
+      "value":"Dockerfile"
+    },
+    {
+      "name":"OWNERNAME",
+      "displayName":"Owner Name",
+      "description":"Owner Name for cascading delition",
+      "value":"none"
+    },
+    {
+      "name":"UID",
+      "displayName":"Owner uid",
+      "description":"Onwer uid for cascading delition",
+      "value":"none"
+    }
+  ]
+}

--- a/resources/com/github/coreos/job.yaml
+++ b/resources/com/github/coreos/job.yaml
@@ -1,0 +1,24 @@
+kind: Template
+apiVersion: v1
+metadata:
+  name: clean-up
+objects:
+- apiVersion: batch/v1
+  kind: Job
+  metadata:
+    name: "${NAME}"
+  spec:
+    ttlSecondsAfterFinished: 100
+    template:
+      spec:
+        containers:
+        - name: "${NAME}"
+          image: fedora:33
+          command:
+          - sleep
+          - 2h
+        restartPolicy: Never
+parameters:
+- name: NAME
+  required: true
+  value: cleanupJob

--- a/vars/buildImage.groovy
+++ b/vars/buildImage.groovy
@@ -1,0 +1,70 @@
+// Builds a container image and returns its name.
+// Available parameters:
+//    dockerFile    string -- DockerFile used for the buildconfig
+//    workspace     string -- Path for local source dir used for `--from-dir=`
+def call(params = [:]) {
+    def imageName
+    def bcObj
+
+    openshift.withCluster() {
+        openshift.withProject() {
+            stage('CleanUp') {
+            // Once we have the TTL controller enabled we can remove this stage
+            // More: https://kubernetes.io/docs/concepts/workloads/controllers/ttlafterfinished/
+                def jobs = openshift.selector("jobs").names()
+                for (job in jobs) {
+                    if (job.startsWith('job/coreos-ci')) {
+                        def obj = openshift.selector(job).object()
+                        if (obj.status.completionTime) {
+                            openshift.selector(job).delete()
+                        }
+                    }
+                }
+            }
+            stage('Prepare Env') {
+                // TODO: Change buidlconfig to yaml and to use openshift.process
+                // Issue described in:
+                // https://github.com/coreos/coreos-ci-lib/pull/61#discussion_r569401940
+                def bcJSON  = libraryResource 'com/github/coreos/buildconfig.json'
+                def jobYaml = libraryResource 'com/github/coreos/job.yaml'
+                def jobObj  = readYaml text: jobYaml
+                bcObj       = readJSON text: bcJSON
+
+                def UUID    = UUID.randomUUID()
+                def scmVars = checkout scm
+                def repo    = (scmVars.GIT_URL.substring(scmVars.GIT_URL.lastIndexOf('/') + 1)).replace('.git','')
+
+                jobObj      = openshift.process(jobObj, "-p", "NAME=coreos-ci-$repo-${UUID}")
+                def app     = openshift.create(jobObj)
+                def job     = app.narrow('job')
+                def jobMap  = job.object()
+                def uid     = jobMap.metadata.get('uid')
+
+                imageName = "coreos-ci-$repo-${UUID}"
+
+                //Create and unique name for image and bc
+                bcObj['parameters'][0] +=['name': 'NAME', 'value': "coreos-ci-$repo-${UUID}".toString()]
+
+                //Add OwnerReference for cascading deletion with the Job timeout
+                bcObj['parameters'][3] +=['name': 'UID', 'value': "${uid}".toString()]
+                bcObj['parameters'][2] +=['name': 'OWNERNAME', 'value': "coreos-ci-$repo-${UUID}".toString()]
+                if (params['dockerFile']) {
+                    bcObj['parameters'][1] +=['name': 'DOCKERFILE', 'value': "${params['dockerFile']}".toString()]
+                }
+            }
+            stage('Create BuildConfig') {
+                openshift.create(openshift.process(bcObj))
+            }
+            stage('Build') {
+                def workspace = params.get('workspace', ".");
+                shwrap("tar --exclude=./pod* -zcf /tmp/dir.tar ${workspace}")
+                def bc = openshift.selector('bc', imageName).startBuild("--from-archive=/tmp/dir.tar")
+
+                // Showing logs in Jenkins is also a way
+                // to wait for the build to finsih
+                bc.logs('-f')
+           }
+        }
+    }
+    return imageName.toString()
+}


### PR DESCRIPTION
Create a buildconfig and trigger the build for
coreos-assembler creating a imageStream for it.

It allows us to split the build process in 2 phases.
The coreos-assembler build will be done via DockerFile
the same way we have in most of our CIs today.

Signed-off-by: Renata Ravanelli <rravanel@redhat.com>