### PR TITLE
Drop support for `cosaPod(buildroot: true)`; add `buildPod`

### DIFF
--- a/vars/buildPod.groovy
+++ b/vars/buildPod.groovy
@@ -1,0 +1,15 @@
+// Thin wrapper around pod() which fills in the FCOS buildroot images.
+// Additional available parameters:
+//   image: string
+//   buildroot: bool
+def call(params = [:], Closure body) {
+    if (params['stream'] == null) {
+        params['stream'] = 'testing-devel'
+    }
+
+    params['image'] = "quay.io/coreos-assembler/fcos-buildroot:${params['stream']}"
+
+    pod(params) {
+        body()
+    }
+}

--- a/vars/cosaPod.groovy
+++ b/vars/cosaPod.groovy
@@ -1,14 +1,9 @@
 // Thin wrapper around pod() which auto-selects images and kvm.
 // Additional available parameters:
 //   image: string
-//   buildroot: bool
 def call(params = [:], Closure body) {
     if (params['image'] == null) {
-        if (params['buildroot']) {
-            params['image'] = 'registry.svc.ci.openshift.org/coreos/cosa-buildroot:latest'
-        } else {
-            params['image'] = 'quay.io/coreos-assembler/coreos-assembler:latest'
-        }
+        params['image'] = 'quay.io/coreos-assembler/coreos-assembler:latest'
     }
 
     // default to enabling KVM


### PR DESCRIPTION
We're moving away from a buildroot image based on cosa to one based on
FCOS:

https://github.com/coreos/fedora-coreos-config/pull/740

Correspondingly, add a new `buildPod` as a thin sugar for selecting that
image.