### PR TITLE
Explicitly parse param for stream

### DIFF
--- a/vars/buildPod.groovy
+++ b/vars/buildPod.groovy
@@ -1,13 +1,10 @@
-// Thin wrapper around pod() which fills in the FCOS buildroot images.
+// buildPod is a thin wrapper around pod() which fills in the FCOS buildroot images.
 // Additional available parameters:
 //   image: string
 //   buildroot: bool
 def call(params = [:], Closure body) {
-    if (params['stream'] == null) {
-        params['stream'] = 'testing-devel'
-    }
-
-    params['image'] = "quay.io/coreos-assembler/fcos-buildroot:${params['stream']}"
+    def stream = params.get('stream', 'testing-devel');
+    params['image'] = "quay.io/coreos-assembler/fcos-buildroot:${stream}"
 
     pod(params) {
         body()

--- a/vars/pod.groovy
+++ b/vars/pod.groovy
@@ -1,4 +1,4 @@
-// Run the passed body in a pod respecting some parameters.
+// pod runs the passed body in a Kubernetes pod respecting some parameters.
 // Available parameters:
 //   image: string
 //   kvm: bool


### PR DESCRIPTION
I think this may be the cause of failure, but I'm not totally sure.

I also added `buildPod` in the file because otherwise grep doesn't
find it.