### PR TITLE
buildPod: explicitly cast image to string

### DIFF
--- a/vars/buildPod.groovy
+++ b/vars/buildPod.groovy
@@ -4,7 +4,7 @@
 //   buildroot: bool
 def call(params = [:], Closure body) {
     def stream = params.get('stream', 'testing-devel');
-    params['image'] = "quay.io/coreos-assembler/fcos-buildroot:${stream}"
+    params['image'] = "quay.io/coreos-assembler/fcos-buildroot:${stream}".toString()
 
     pod(params) {
         body()


### PR DESCRIPTION
I think otherwise Groovy doesn't know that it's a string for some
reason and keeps it as an array of different element types or something.