### PR TITLE
buildPod: use dumb-init by default

### DIFF
--- a/vars/buildPod.groovy
+++ b/vars/buildPod.groovy
@@ -6,6 +6,9 @@ def call(params = [:], Closure body) {
     def stream = params.get('stream', 'testing-devel');
     params['image'] = "quay.io/coreos-assembler/fcos-buildroot:${stream}".toString()
 
+    // we don't like zombies
+    params['cmd'] = ["/usr/bin/dumb-init", "/usr/bin/sleep", "infinity"]
+
     pod(params) {
         body()
     }


### PR DESCRIPTION
Otherwise, we risk running out of resources in our pods.