### PR TITLE
buildPod: Support overriding image

### DIFF
--- a/vars/buildPod.groovy
+++ b/vars/buildPod.groovy
@@ -4,7 +4,7 @@
 //   buildroot: bool
 def call(params = [:], Closure body) {
     def stream = params.get('stream', 'testing-devel');
-    params['image'] = "quay.io/coreos-assembler/fcos-buildroot:${stream}".toString()
+    params['image'] = params.get('image', "quay.io/coreos-assembler/fcos-buildroot:${stream}".toString());
 
     // we don't like zombies
     params['cmd'] = ["/usr/bin/dumb-init", "/usr/bin/sleep", "infinity"]


### PR DESCRIPTION
So it's easier to test alternative images; motivated by
https://github.com/coreos/fedora-coreos-config/pull/932