### PR TITLE
pod: Add param sa (serviceAccount) in pod

### DIFF
--- a/vars/pod.groovy
+++ b/vars/pod.groovy
@@ -7,12 +7,17 @@
 //   cpu: amount of CPU to request
 //   emptyDirs: []string
 //   cmd: []string
+//   serviceAccount: string
 //   secrets: []string
 //   configMaps: []string
 def call(params = [:], Closure body) {
     def podJSON = libraryResource 'com/github/coreos/pod.json'
     def podObj = readJSON text: podJSON
     podObj['spec']['containers'][0]['image'] = params['image']
+
+    if (params['serviceAccount'] != null) {
+        podObj['spec']['containers'][0]['serviceAccount'] = params['serviceAccount']
+    }
 
     if (params['runAsUser'] != null) {
         podObj['spec']['containers'][0]['securityContext'] = [runAsUser: params['runAsUser']]


### PR DESCRIPTION
 - In order to run gangplank we need to use jenkins
 service account, let's allow this option in pod

Signed-off-by: Renata Ravanelli <rravanel@redhat.com>