### PR TITLE
fcosBuild: Fix branch reference

### DIFF
--- a/vars/fcosBuild.groovy
+++ b/vars/fcosBuild.groovy
@@ -19,7 +19,12 @@ def call(params = [:]) {
         shwrap("mkdir -p ${cosaDir}")
 
         if (!params['skipInit']) {
-            shwrap("cd ${cosaDir} && cosa init https://github.com/coreos/fedora-coreos-config")
+            shwrap("cd ${cosaDir} && git clone https://github.com/coreos/fedora-coreos-config src/config")
+            if (env.BRANCH_NAME != "main") {
+                git_branch = shwrapCapture("git name-rev --name-only HEAD | sed 's|.*/||'")
+                shwrap("pushd ${cosaDir}/src/config && git checkout origin/${git_branch}")
+            }
+            shwrap("cd ${cosaDir} && cosa init --force ${cosaDir}/src/config")
         }
 
         if (params['make']) {


### PR DESCRIPTION
- It will always point to the main branch even
if we are running the CI for other branches.
For this case we need to match the fedora-coreos-config
branch with the CI branch running.

Signed-off-by: Renata Ravanelli <rravanel@redhat.com>