### PR TITLE
Revert "fcosBuild: Fix branch reference"

### DIFF
--- a/vars/fcosBuild.groovy
+++ b/vars/fcosBuild.groovy
@@ -19,12 +19,7 @@ def call(params = [:]) {
         shwrap("mkdir -p ${cosaDir}")
 
         if (!params['skipInit']) {
-            shwrap("cd ${cosaDir} && git clone https://github.com/coreos/fedora-coreos-config src/config")
-            if (env.BRANCH_NAME != "main") {
-                git_branch = shwrapCapture("git name-rev --name-only HEAD | sed 's|.*/||'")
-                shwrap("pushd ${cosaDir}/src/config && git checkout origin/${git_branch}")
-            }
-            shwrap("cd ${cosaDir} && cosa init --force ${cosaDir}/src/config")
+            shwrap("cd ${cosaDir} && cosa init https://github.com/coreos/fedora-coreos-config")
         }
 
         if (params['make']) {


### PR DESCRIPTION
This reverts commit 64916e000d007716fe18a2d13766cba8e81b3f3a.

This is breaking coreos-assembler CI:
https://github.com/coreos/coreos-ci-lib/pull/79#issuecomment-848119026

But also this seems overly specific to coreos-assembler and how that
repo and the fedora-coreos-config repo is set up.

We should probably instead in those cases leverage `skipInit` where
needed to have full control over what branches we want to check out.