### PR TITLE
fcosKolaTestIso: fix name of `iso-as-disk` scenario

### DIFF
--- a/vars/fcosKolaTestIso.groovy
+++ b/vars/fcosKolaTestIso.groovy
@@ -23,7 +23,7 @@ def call(params = [:]) {
     // only one test by default
     def scenariosMultipath = params.get('scenariosMultipath', "iso-offline-install");
     // by default, only test that we can boot successfully
-    def scenariosUEFI = params.get('scenariosUEFI', "iso-live-login,iso-add-disk");
+    def scenariosUEFI = params.get('scenariosUEFI', "iso-live-login,iso-as-disk");
 
     testIsoRuns1 = [:]
     testIsoRuns2 = [:]


### PR DESCRIPTION
Fixes https://github.com/coreos/coreos-ci-lib/pull/88.