### PR TITLE
fcosKola: don't use `parallel` for single runs

### DIFF
--- a/vars/fcosKola.groovy
+++ b/vars/fcosKola.groovy
@@ -76,6 +76,10 @@ def call(params = [:]) {
     }
 
     stage('Kola') {
-        parallel(kolaRuns)
+        if (kolaRuns.size() == 1) {
+            kolaRuns.each { it -> it.value() }
+        } else {
+            parallel(kolaRuns)
+        }
     }
 }


### PR DESCRIPTION
That should make the Blue Ocean view less messy.

Related: https://github.com/coreos/coreos-ci-lib/issues/95