### PR TITLE
fcosKola: don't use `it` variable

### DIFF
--- a/vars/fcosKola.groovy
+++ b/vars/fcosKola.groovy
@@ -77,7 +77,7 @@ def call(params = [:]) {
 
     stage('Kola') {
         if (kolaRuns.size() == 1) {
-            kolaRuns.each { it -> it.value() }
+            kolaRuns.each { k, v -> v() }
         } else {
             parallel(kolaRuns)
         }


### PR DESCRIPTION
Jenkins is complaining about `it` already existing, which I'm not sure
why. I don't see it existing elsewhere, and the overall pattern works
fine when manually testing in the Jenkins script console. Let's just try
instead using the `k, v` pattern.

Fixes: #96