### PR TITLE
fcosKola: make project test name consistent

### DIFF
--- a/vars/fcosKola.groovy
+++ b/vars/fcosKola.groovy
@@ -49,7 +49,12 @@ def call(params = [:]) {
             test "\$configorigin" != "\$gitorigin"
         """) == 0)
         {
-            args += "--exttest ${env.WORKSPACE}"
+            // The workspace name created by Jenkins is messy and dynamic, but
+            // kola uses it to derive the test name. Let's fix it by using a
+            // symlinked dir.
+            def name = shwrapCapture("basename \$(git config --get remote.origin.url) .git")
+            shwrap("mkdir -p /var/tmp/kola && ln -s ${env.WORKSPACE} /var/tmp/kola/${name}")
+            args += "--exttest /var/tmp/kola/${name}"
         }
         def parallel = params.get('parallel', 8);
         def extraArgs = params.get('extraArgs', "");


### PR DESCRIPTION
Right now the kola external tests specific to a project have different
names on each run because it's affected by the workspace directory name,
which Jenkins names something like e.g. hub-ci_coreos_rpm-ostree_PR-3327
which isn't very friendly.

This prevents us from having sane globs and makes output messier.

Let's just get the project name from the git URL and pass a symlink
named as such to kola.