### PR TITLE
fcosKolaTestiso: add test for add-nm-keyfile switch with iso-install

### DIFF
--- a/vars/fcosKolaTestIso.groovy
+++ b/vars/fcosKolaTestIso.groovy
@@ -34,6 +34,7 @@ def call(params = [:]) {
             } else {
                 shwrap("cd ${cosaDir}  && kola testiso -S ${extraArgs} --output-dir tmp/kola-testiso-metal")
             }
+            shwrap("cd ${cosaDir}  && kola testiso -S --add-nm-keyfile --scenarios iso-install --output-dir tmp/kola-testiso-metal")
         } finally {
             shwrap("cd ${cosaDir} && tar -cf - tmp/kola-testiso-metal/ | xz -c9 > ${env.WORKSPACE}/kola-testiso-metal.tar.xz")
             archiveArtifacts allowEmptyArchive: true, artifacts: 'kola-testiso-metal.tar.xz'
@@ -47,6 +48,7 @@ def call(params = [:]) {
                 } else {
                     shwrap("cd ${cosaDir} &&  kola testiso -S --qemu-native-4k ${extraArgs4k} --output-dir tmp/kola-testiso-metal4k")
                 }
+                shwrap("cd ${cosaDir}  && kola testiso -S --qemu-native-4k --add-nm-keyfile --scenarios iso-install --output-dir tmp/kola-testiso-metal4k")
             } finally {
                 shwrap("cd ${cosaDir} && tar -cf - tmp/kola-testiso-metal4k/ | xz -c9 > ${env.WORKSPACE}/kola-testiso-metal4k.tar.xz")
                 archiveArtifacts allowEmptyArchive: true, artifacts: 'kola-testiso-metal4k.tar.xz'


### PR DESCRIPTION
Add additional test to test the `--copy-network` path. We are using the `--add-nm-keyfile` switch to test it with `iso-install` scenario.
Issue: https://github.com/coreos/coreos-assembler/issues/1987