### PR TITLE
gangplank: print message if command finished cleanly

### DIFF
--- a/vars/gangplank.groovy
+++ b/vars/gangplank.groovy
@@ -87,6 +87,7 @@ def startMinio(params =[:]) {
 def _runGangplank(gangplankCmd) {
     try {
         shwrap("${gangplankCmd}")
+        echo "Gangplank command finished successfully!"
     } catch (Exception e) {
         print(e)
         currentBuild.result = 'ABORTED'


### PR DESCRIPTION
We're suspecting that the gangplank command may be exiting 0 even when
test failures occurred. Add an echo after to check this: if it's printed
then it must mean that `shwrap` didn't throw an exception.