### PR TITLE
pod: use serviceAccountName instead of serviceAccount

### DIFF
--- a/vars/pod.groovy
+++ b/vars/pod.groovy
@@ -18,11 +18,11 @@ def call(params = [:], Closure body) {
     if (params['runAsUser'] != null) {
         podObj['spec']['containers'][0]['securityContext'] = [runAsUser: params['runAsUser']]
         // https://pagure.io/fedora-infra/ansible/blob/9244b4c12256/f/roles/openshift-apps/coreos-ci/defaults/main.yaml#_3
-        podObj['spec']['serviceAccount'] = 'coreos-ci-sa'
+        podObj['spec']['serviceAccountName'] = 'coreos-ci-sa'
     }
 
     if (params['serviceAccount'] != null) {
-        podObj['spec']['serviceAccount'] = params['serviceAccount']
+        podObj['spec']['serviceAccountName'] = params['serviceAccount']
     }
 
     // initialize some maps/lists to make it easier to populate later on


### PR DESCRIPTION
The latter is deprecated. It should still work at the k8s level, but
it's possible there's something going on with the Jenkins kubernetes
plugin not handling this correctly.