### PR TITLE
Move from Quay.io to app.ci

### DIFF
--- a/vars/buildPod.groovy
+++ b/vars/buildPod.groovy
@@ -4,7 +4,7 @@
 //   buildroot: bool
 def call(params = [:], Closure body) {
     def stream = params.get('stream', 'testing-devel');
-    params['image'] = params.get('image', "quay.io/coreos-assembler/fcos-buildroot:${stream}".toString());
+    params['image'] = params.get('image', "registry.ci.openshift.org/coreos/fcos-buildroot:${stream}".toString());
 
     // we don't like zombies
     params['cmd'] = ["/usr/bin/dumb-init", "/usr/bin/sleep", "infinity"]

--- a/vars/cosaPod.groovy
+++ b/vars/cosaPod.groovy
@@ -3,7 +3,7 @@
 //   image: string
 def call(params = [:], Closure body) {
     if (params['image'] == null) {
-        params['image'] = 'quay.io/coreos-assembler/coreos-assembler:latest'
+        params['image'] = 'registry.ci.openshift.org/coreos/coreos-assembler:latest'
     }
 
     // default to enabling KVM


### PR DESCRIPTION
The latter mirrors to the former, but it's a periodic that runs every
hour. So let's just use the images directly from app.ci for faster
iteration.