### PR TITLE
buildImage: fix resource request

### DIFF
--- a/vars/buildImage.groovy
+++ b/vars/buildImage.groovy
@@ -62,6 +62,8 @@ def call(params = [:]) {
                 params['env'].each{ name, val ->
                     bcObj['objects'][1]['spec']['strategy']['dockerStrategy']['env'] += ['name': name, 'value': val]
                 }
+                // initialize so we can populate it more easily
+                bcObj['objects'][1]['spec']['resources'] = [requests: [:], limits: [:]]
                 if (params['memory']) {
                     bcObj['objects'][1]['spec']['resources']['requests']['memory'] = params['memory'].toString()
                 }


### PR DESCRIPTION
We need to initialize the maps before we can set keys inside.

Fixes decacbc ("buildImage: add support for setting memory and cpu").