### PR TITLE
fcosKola: parallelize kola to the number of CPUs

### DIFF
--- a/vars/fcosKola.groovy
+++ b/vars/fcosKola.groovy
@@ -2,7 +2,7 @@
 // Available parameters:
 //    addExtTests:       []string -- list of test paths to run
 //    cosaDir:           string   -- cosa working directory
-//    parallel:          integer  -- number of tests to run in parallel (default: 8)
+//    parallel:          integer  -- number of tests to run in parallel (default: # CPUs)
 //    skipBasicScenarios boolean  -- skip basic qemu scenarios
 //    skipUpgrade:       boolean  -- skip running `cosa kola --upgrades`
 //    build:             string   -- cosa build ID to target
@@ -56,7 +56,7 @@ def call(params = [:]) {
             shwrap("mkdir -p /var/tmp/kola && ln -s ${env.WORKSPACE} /var/tmp/kola/${name}")
             args += "--exttest /var/tmp/kola/${name}"
         }
-        def parallel = params.get('parallel', 8);
+        def parallel = params.get('parallel', "auto");
         def extraArgs = params.get('extraArgs', "");
         def addExtTests = params.get('addExtTests', [])
 


### PR DESCRIPTION
As of 7b552e1134, we're enforcing CPU resource limits on our pods.  The current defaults allocate 2 CPUs and then use them to run 8 parallel kola tests and a kola upgrade test.  Reduce oversubscription by having kola parallelize to the number of available CPUs by default.  There's still some oversubscription because we're running the kola upgrade test in parallel with that, but that currently only needs 1 CPU.