### PR TITLE
cosaPod: point back to Quay.io for cosa

### DIFF
--- a/vars/cosaPod.groovy
+++ b/vars/cosaPod.groovy
@@ -3,7 +3,7 @@
 //   image: string
 def call(params = [:], Closure body) {
     if (params['image'] == null) {
-        params['image'] = 'registry.ci.openshift.org/coreos/coreos-assembler:latest'
+        params['image'] = 'quay.io/coreos-assembler/coreos-assembler:main'
     }
 
     // default to enabling KVM


### PR DESCRIPTION
The canonical location is Quay.io again so let's use that so we don't
have to wait for app.ci to mirror it.