### PR TITLE
job.yaml: switch to minimal image; use :latest tag

### DIFF
--- a/resources/com/github/coreos/job.yaml
+++ b/resources/com/github/coreos/job.yaml
@@ -17,7 +17,7 @@ objects:
       spec:
         containers:
         - name: "${NAME}"
-          image: registry.fedoraproject.org/fedora:34
+          image: registry.fedoraproject.org/fedora-minimal:latest
           command:
           - sleep
           - 24h


### PR DESCRIPTION
Since the role of the container here is super minimal let's just use the minimal container and also follow the :latest tag so that we don't ever have to worry about being on an EOL release.