### PR TITLE
pod: set memory limit also

### DIFF
--- a/vars/pod.groovy
+++ b/vars/pod.groovy
@@ -32,6 +32,7 @@ def call(params = [:], Closure body) {
 
     if (params['memory']) {
         podObj['spec']['containers'][0]['resources']['requests']['memory'] = params['memory'].toString()
+        podObj['spec']['containers'][0]['resources']['limits']['memory'] = params['memory'].toString()
     }
     // just default to 2 cpu-equivalent if unspecified
     if (params['cpu'] == null) {


### PR DESCRIPTION
When deploying the RHCOS pipeline we ran into a case where there was a limitrange set with a default memory limit:

```
oc describe limitrange
Type        Resource  Min  Max  Default Request  Default Limit  Max Limit/Request Ratio
----        --------  ---  ---  ---------------  -------------  -----------------------
Container   cpu       -    -    300m             4              -
Container   memory    -    -    400Mi            6656Mi         -
```

In this case we also needed to bump the memory for the COSA pod to 8Gi. Bumping it to 8Gi (via cosaPod()) set the request but not the limit. The pod inherited the default limit of 6656 Mi and we got an error:

```
Invalid value: "8Gi": must be less than or equal to memory limit
```

Let's just set the limit to the same value as the request here. We'll adapt later if we find we need more knobs.