### PR TITLE
Add `tryWithCredentials` custom step

### DIFF
--- a/vars/tryWithCredentials.groovy
+++ b/vars/tryWithCredentials.groovy
@@ -1,0 +1,12 @@
+import org.jenkinsci.plugins.credentialsbinding.impl.CredentialNotFoundException
+
+// Runs closure if credentials exist, otherwise gracefully return.
+def call(creds, Closure body) {
+    try {
+        withCredentials(creds) {
+            body()
+        }
+    } catch (CredentialNotFoundException e) {
+        echo("${e.getMessage()}: skipping")
+    }
+}


### PR DESCRIPTION
This new step can be used just like `withCredentials`, except that if the credentials don't exist, we'll gracefully return.

Upstreamed from the FCOS pipeline.