### PR TITLE
utils: add substituteStr

### DIFF
--- a/vars/utils.groovy
+++ b/vars/utils.groovy
@@ -25,3 +25,12 @@ def getCosaDir(params = [:]) {
 def pathExists(path) {
     return shwrapRc("test -e ${path}") == 0
 }
+
+// Thin wrapper around SimpleTemplateEngine().
+//     tmpl_str    string  -- templated string
+//     bindings    map     -- variables to fill in
+def substituteStr(tmpl_str, bindings) {
+    def engine = new groovy.text.SimpleTemplateEngine()
+    def tmpl = engine.createTemplate(tmpl_str).make(bindings)
+    return tmpl.toString()
+}


### PR DESCRIPTION
This will be used by the pipeline to process some of the templated fields in `config.yaml`. Putting it here allows us to work around the fact that the `SimpleTemplateEngine` API would normally have to be allowed by an administrator first.