### PR TITLE
rework kola/kolaTestIso functions

### DIFF
--- a/vars/kola.groovy
+++ b/vars/kola.groovy
@@ -141,7 +141,7 @@ def call(params = [:]) {
                 // sanity check kola actually ran and dumped its output
                 shwrap("cosa shell -- test -d ${outputDir}/${id}")
                 // collect the output
-                shwrap("cosa shell -- tar -c --xz ${outputDir}/${id} > ${env.WORKSPACE}/${id}-${token}.tar.xz")
+                shwrap("cosa shell -- tar -c --xz ${outputDir}/${id} > ${env.WORKSPACE}/${id}-${token}.tar.xz || :")
                 archiveArtifacts allowEmptyArchive: true, artifacts: "${id}-${token}.tar.xz"
             }
         }

--- a/vars/kola.groovy
+++ b/vars/kola.groovy
@@ -1,6 +1,7 @@
 // Run kola tests on the latest build in the cosa dir
 // Available parameters:
 //    addExtTests:       []string -- list of test paths to run
+//    arch:              string   -- the target architecture
 //    cosaDir:           string   -- cosa working directory
 //    parallel:          integer  -- number of tests to run in parallel (default: # CPUs)
 //    skipBasicScenarios boolean  -- skip basic qemu scenarios
@@ -16,22 +17,20 @@ def call(params = [:]) {
     // this is shared between `kola run` and `kola run-upgrade`
     def platformArgs = params.get('platformArgs', "");
     def buildID = params.get('build', "latest");
-    def arch = params.get('arch', "");
+    def arch = params.get('arch', "x86_64");
     def marker = params.get('marker', "kola");
     def rerun = "--rerun"
     if (params.get('disableRerun', false)) {
         rerun = ""
     }
-    if (arch != "") {
-        arch = "--arch=${arch}"
-    }
+    def archArg = "--arch=${arch}"
 
     // Define a unique token to be added to the file name uploads
     // Prevents multiple runs overwriting same filename in archiveArtifacts
     def token = shwrapCapture("uuidgen | cut -f1 -d-")
 
     // Create a unique output directory for this run of kola
-    def outputDir = shwrapCapture("mktemp -d ${cosaDir}/tmp/kola-XXXXX")
+    def outputDir = shwrapCapture("cosa shell -- mktemp -d ${cosaDir}/tmp/kola-XXXXX")
 
     // list of identifiers for each run for log collection
     def ids = []
@@ -55,9 +54,16 @@ def call(params = [:]) {
         {
             // The workspace name created by Jenkins is messy and dynamic, but
             // kola uses it to derive the test name. Let's fix it by using a
-            // symlinked dir.
+            // symlinked dir (x86_64) or copied dir (multi-arch).
             def name = shwrapCapture("basename \$(git config --get remote.origin.url) .git")
-            shwrap("mkdir -p /var/tmp/kola && ln -s ${env.WORKSPACE} /var/tmp/kola/${name}")
+            if (arch == 'x86_64') {
+                shwrap("mkdir -p /var/tmp/kola && ln -s ${env.WORKSPACE} /var/tmp/kola/${name}")
+            } else {
+                shwrap("""
+                cosa shell -- mkdir -p /var/tmp/kola
+                cosa remote-session sync ${env.WORKSPACE}/ :/var/tmp/kola/${name}/
+                """)
+            }
             args += "--exttest /var/tmp/kola/${name}"
         }
         def parallel = params.get('parallel', "auto");
@@ -72,41 +78,43 @@ def call(params = [:]) {
         if (!params['skipBasicScenarios']) {
             id = marker == "" ? "kola-basic" : "kola-basic-${marker}"
             ids += id
-            shwrap("cd ${cosaDir} && cosa kola run ${rerun} --output-dir=${outputDir}/${id} --basic-qemu-scenarios")
+            shwrap("cosa kola run ${rerun} --output-dir=${outputDir}/${id} --basic-qemu-scenarios")
         }
         // normal run (without reprovision tests because those require a lot of memory)
         id = marker == "" ? "kola" : "kola-${marker}"
         ids += id
-        shwrap("cd ${cosaDir} && cosa kola run ${rerun} --output-dir=${outputDir}/${id} --build=${buildID} ${arch} ${platformArgs} --tag '!reprovision' --parallel ${parallel} ${args} ${extraArgs}")
+        shwrap("cosa kola run ${rerun} --output-dir=${outputDir}/${id} --build=${buildID} ${archArg} ${platformArgs} --tag '!reprovision' --parallel ${parallel} ${args} ${extraArgs}")
 
         // re-provision tests (not run with --parallel argument to kola)
         id = marker == "" ? "kola-reprovision" : "kola-reprovision-${marker}"
         ids += id
-        shwrap("cd ${cosaDir} && cosa kola run ${rerun} --output-dir=${outputDir}/${id} --build=${buildID} ${arch} ${platformArgs} --tag reprovision ${args} ${extraArgs}")
+        shwrap("cosa kola run ${rerun} --output-dir=${outputDir}/${id} --build=${buildID} ${archArg} ${platformArgs} --tag reprovision ${args} ${extraArgs}")
     }
 
     if (!params["skipUpgrade"]) {
         kolaRuns['run_upgrades'] = {
             def id = marker == "" ? "kola-upgrade" : "kola-upgrade-${marker}"
             ids += id
-            shwrap("cd ${cosaDir} && cosa kola ${rerun} --output-dir=${outputDir}/${id} --upgrades --build=${buildID} ${arch} ${platformArgs}")
+            shwrap("cosa kola ${rerun} --output-dir=${outputDir}/${id} --upgrades --build=${buildID} ${archArg} ${platformArgs}")
         }
     }
 
     stage('Kola') {
-        try {
-            if (kolaRuns.size() == 1) {
-                kolaRuns.each { k, v -> v() }
-            } else {
-                parallel(kolaRuns)
-            }
-        } finally {
-            for (id in ids) {
-                // sanity check kola actually ran and dumped its output
-                shwrap("test -d ${outputDir}/${id}")
-                // collect the output
-                shwrap("tar -c -C ${outputDir} ${id} | xz -c9 > ${env.WORKSPACE}/${id}-${token}.tar.xz")
-                archiveArtifacts allowEmptyArchive: true, artifacts: "${id}-${token}.tar.xz"
+        dir(cosaDir) {
+            try {
+                if (kolaRuns.size() == 1) {
+                    kolaRuns.each { k, v -> v() }
+                } else {
+                    parallel(kolaRuns)
+                }
+            } finally {
+                for (id in ids) {
+                    // sanity check kola actually ran and dumped its output
+                    shwrap("cosa shell -- test -d ${outputDir}/${id}")
+                    // collect the output
+                    shwrap("cosa shell -- tar -c --xz ${outputDir}/${id} > ${env.WORKSPACE}/${id}-${token}.tar.xz")
+                    archiveArtifacts allowEmptyArchive: true, artifacts: "${id}-${token}.tar.xz"
+                }
             }
         }
     }

--- a/vars/kola.groovy
+++ b/vars/kola.groovy
@@ -128,22 +128,21 @@ def call(params = [:]) {
         }
     }
 
-    stage('Kola') {
-        dir(cosaDir) {
-            try {
-                if (kolaRuns.size() == 1) {
-                    kolaRuns.each { k, v -> v() }
-                } else {
-                    parallel(kolaRuns)
-                }
-            } finally {
-                for (id in ids) {
-                    // sanity check kola actually ran and dumped its output
-                    shwrap("cosa shell -- test -d ${outputDir}/${id}")
-                    // collect the output
-                    shwrap("cosa shell -- tar -c --xz ${outputDir}/${id} > ${env.WORKSPACE}/${id}-${token}.tar.xz")
-                    archiveArtifacts allowEmptyArchive: true, artifacts: "${id}-${token}.tar.xz"
-                }
+    // Run the Kola tests from the cosaDir
+    dir(cosaDir) {
+        try {
+            if (kolaRuns.size() == 1) {
+                kolaRuns.each { k, v -> v() }
+            } else {
+                parallel(kolaRuns)
+            }
+        } finally {
+            for (id in ids) {
+                // sanity check kola actually ran and dumped its output
+                shwrap("cosa shell -- test -d ${outputDir}/${id}")
+                // collect the output
+                shwrap("cosa shell -- tar -c --xz ${outputDir}/${id} > ${env.WORKSPACE}/${id}-${token}.tar.xz")
+                archiveArtifacts allowEmptyArchive: true, artifacts: "${id}-${token}.tar.xz"
             }
         }
     }

--- a/vars/kola.groovy
+++ b/vars/kola.groovy
@@ -41,7 +41,7 @@ def call(params = [:]) {
     // conditionally only add the `run_upgrades` stage if not explicitly
     // skipped.
     def kolaRuns = [:]
-    kolaRuns["run"] = {
+    kolaRuns["${arch}:kola"] = {
         def args = ""
         def id
         // Add the tests/kola directory, but only if it's not the same as the
@@ -108,7 +108,7 @@ def call(params = [:]) {
     }
 
     if (!params["skipUpgrade"]) {
-        kolaRuns['run_upgrades'] = {
+        kolaRuns["${arch}:kola:upgrade"] = {
             // If upgrades are broken `cosa kola --upgrades` might
             // fail to even find the previous image so we wrap this
             // in a try/catch so allowUpgradeFail can work.

--- a/vars/kolaTestIso.groovy
+++ b/vars/kolaTestIso.groovy
@@ -29,11 +29,8 @@ def call(params = [:]) {
     testIsoRuns2 = [:]
     testIsoRuns1["metal"] = {
         try {
-            if (params['scenarios']) {
-                shwrap("cd ${cosaDir}  && kola testiso -S ${extraArgs} --scenarios ${scenarios} --output-dir tmp/kola-testiso-metal")
-            } else {
-                shwrap("cd ${cosaDir}  && kola testiso -S ${extraArgs} --output-dir tmp/kola-testiso-metal")
-            }
+            def scenariosArg = scenarios == "" ? "" : "--scenarios ${scenarios}"
+            shwrap("cd ${cosaDir} && kola testiso -S ${extraArgs} ${scenariosArg} --output-dir tmp/kola-testiso-metal")
         } finally {
             shwrap("cd ${cosaDir} && tar -cf - tmp/kola-testiso-metal/ | xz -c9 > ${env.WORKSPACE}/kola-testiso-metal.tar.xz")
             archiveArtifacts allowEmptyArchive: true, artifacts: 'kola-testiso-metal.tar.xz'
@@ -42,11 +39,8 @@ def call(params = [:]) {
     if (!params['skipMetal4k']) {
         testIsoRuns1["metal4k"] = {
             try {
-                if (params['scenarios4k']) {
-                    shwrap("cd ${cosaDir} &&  kola testiso -S --qemu-native-4k ${extraArgs4k} --scenarios ${scenarios4k} --output-dir tmp/kola-testiso-metal4k")
-                } else {
-                    shwrap("cd ${cosaDir} &&  kola testiso -S --qemu-native-4k ${extraArgs4k} --output-dir tmp/kola-testiso-metal4k")
-                }
+                def scenariosArg = scenarios4k == "" ? "" : "--scenarios ${scenarios4k}"
+                shwrap("cd ${cosaDir} && kola testiso -S --qemu-native-4k ${extraArgs4k} ${scenariosArg} --output-dir tmp/kola-testiso-metal4k")
             } finally {
                 shwrap("cd ${cosaDir} && tar -cf - tmp/kola-testiso-metal4k/ | xz -c9 > ${env.WORKSPACE}/kola-testiso-metal4k.tar.xz")
                 archiveArtifacts allowEmptyArchive: true, artifacts: 'kola-testiso-metal4k.tar.xz'

--- a/vars/kolaTestIso.groovy
+++ b/vars/kolaTestIso.groovy
@@ -91,7 +91,7 @@ def call(params = [:]) {
             parallel(testIsoRuns2)
         } finally {
             for (id in ids) {
-                shwrap("cosa shell -- tar -c --xz ${outputDir}/${id} > ${env.WORKSPACE}/${id}-${token}.tar.xz")
+                shwrap("cosa shell -- tar -c --xz ${outputDir}/${id} > ${env.WORKSPACE}/${id}-${token}.tar.xz || :")
                 archiveArtifacts allowEmptyArchive: true, artifacts: "${id}-${token}.tar.xz"
             }
         }

--- a/vars/kolaTestIso.groovy
+++ b/vars/kolaTestIso.groovy
@@ -41,7 +41,7 @@ def call(params = [:]) {
 
     testIsoRuns1 = [:]
     testIsoRuns2 = [:]
-    testIsoRuns1["metal"] = {
+    testIsoRuns1["${arch}:kola:metal"] = {
         def id = marker == "" ? "kola-testiso-metal" : "kola-testiso-metal-${marker}"
         ids += id
         def scenariosArg = scenarios == "" ? "" : "--scenarios ${scenarios}"
@@ -52,7 +52,7 @@ def call(params = [:]) {
         // https://github.com/coreos/fedora-coreos-tracker/issues/1261
         // and testiso for s390x doesn't support iso installs either
         if (arch != 's390x') {
-            testIsoRuns1["metal4k"] = {
+            testIsoRuns1["${arch}:kola:metal4k"] = {
                 def id = marker == "" ? "kola-testiso-metal4k" : "kola-testiso-metal4k-${marker}"
                 ids += id
                 def scenariosArg = scenarios4k == "" ? "" : "--scenarios ${scenarios4k}"
@@ -61,7 +61,7 @@ def call(params = [:]) {
         }
     }
     if (!params['skipMultipath']) {
-        testIsoRuns2["multipath"] = {
+        testIsoRuns2["${arch}:kola:multipath"] = {
             def id = marker == "" ? "kola-testiso-multipath" : "kola-testiso-multipath-${marker}"
             ids += id
             shwrap("cosa kola testiso -S --qemu-multipath ${extraArgsMultipath} --scenarios ${scenariosMultipath} --output-dir ${outputDir}/${id}")
@@ -74,7 +74,7 @@ def call(params = [:]) {
         // https://pagure.io/fedora-infrastructure/issue/7361
         // https://github.com/coreos/coreos-assembler/blob/93efb63dcbd63dc04a782e2c6c617ae0cd4a51c8/mantle/platform/qemu.go#L1156
         if (arch == 'x86_64') {
-            testIsoRuns2["metalUEFI"] = {
+            testIsoRuns2["${arch}:kola:uefi"] = {
                 def id = marker == "" ? "kola-testiso-uefi" : "kola-testiso-uefi-${marker}"
                 ids += id
                 shwrap("cosa shell -- mkdir -p ${outputDir}/${id}")

--- a/vars/kolaTestIso.groovy
+++ b/vars/kolaTestIso.groovy
@@ -39,8 +39,8 @@ def call(params = [:]) {
     // list of identifiers for each run for log collection
     def ids = []
 
-    testIsoRuns1 = [:]
-    testIsoRuns2 = [:]
+    def testIsoRuns1 = [:]
+    def testIsoRuns2 = [:]
     testIsoRuns1["${arch}:kola:metal"] = {
         def id = marker == "" ? "kola-testiso-metal" : "kola-testiso-metal-${marker}"
         ids += id

--- a/vars/kolaTestIso.groovy
+++ b/vars/kolaTestIso.groovy
@@ -1,5 +1,6 @@
 // Run kola testiso
 // Available parameters:
+//     arch:               string  -- the target architecture
 //     cosaDir:            string  -- cosa working directory
 //     extraArgs:          string  -- extra arguments to pass to `kola testiso`
 //     extraArgs4k:        string  -- extra arguments to pass to 4k `kola testiso`
@@ -14,6 +15,7 @@
 //     skipUEFI:           boolean -- skip UEFI tests
 //     marker:             string  -- some identifying text to add to uploaded artifact filenames
 def call(params = [:]) {
+    def arch = params.get('arch', "x86_64");
     def cosaDir = utils.getCosaDir(params)
     def extraArgs = params.get('extraArgs', "");
     def extraArgs4k = params.get('extraArgs4k', "");
@@ -32,7 +34,7 @@ def call(params = [:]) {
     def token = shwrapCapture("uuidgen | cut -f1 -d-")
 
     // Create a unique output directory for this run of fcosKola
-    def outputDir = shwrapCapture("mktemp -d ${cosaDir}/tmp/kolaTestIso-XXXXX")
+    def outputDir = shwrapCapture("cosa shell -- mktemp -d ${cosaDir}/tmp/kolaTestIso-XXXXX")
 
     // list of identifiers for each run for log collection
     def ids = []
@@ -43,41 +45,55 @@ def call(params = [:]) {
         def id = marker == "" ? "kola-testiso-metal" : "kola-testiso-metal-${marker}"
         ids += id
         def scenariosArg = scenarios == "" ? "" : "--scenarios ${scenarios}"
-        shwrap("cd ${cosaDir} && kola testiso -S ${extraArgs} ${scenariosArg} --output-dir ${outputDir}/${id}")
+        shwrap("cosa kola testiso -S ${extraArgs} ${scenariosArg} --output-dir ${outputDir}/${id}")
     }
     if (!params['skipMetal4k']) {
-        testIsoRuns1["metal4k"] = {
-            def id = marker == "" ? "kola-testiso-metal4k" : "kola-testiso-metal4k-${marker}"
-            ids += id
-            def scenariosArg = scenarios4k == "" ? "" : "--scenarios ${scenarios4k}"
-            shwrap("cd ${cosaDir} && kola testiso -S --qemu-native-4k ${extraArgs4k} ${scenariosArg} --output-dir ${outputDir}/${id}")
+        // metal4k test doesn't work on s390x for now
+        // https://github.com/coreos/fedora-coreos-tracker/issues/1261
+        // and testiso for s390x doesn't support iso installs either
+        if (arch != 's390x') {
+            testIsoRuns1["metal4k"] = {
+                def id = marker == "" ? "kola-testiso-metal4k" : "kola-testiso-metal4k-${marker}"
+                ids += id
+                def scenariosArg = scenarios4k == "" ? "" : "--scenarios ${scenarios4k}"
+                shwrap("cosa kola testiso -S --qemu-native-4k ${extraArgs4k} ${scenariosArg} --output-dir ${outputDir}/${id}")
+            }
         }
     }
     if (!params['skipMultipath']) {
         testIsoRuns2["multipath"] = {
             def id = marker == "" ? "kola-testiso-multipath" : "kola-testiso-multipath-${marker}"
             ids += id
-            shwrap("cd ${cosaDir} && kola testiso -S --qemu-multipath ${extraArgsMultipath} --scenarios ${scenariosMultipath} --output-dir ${outputDir}/${id}")
+            shwrap("cosa kola testiso -S --qemu-multipath ${extraArgsMultipath} --scenarios ${scenariosMultipath} --output-dir ${outputDir}/${id}")
         }
     }
     if (!params['skipUEFI']) {
-        testIsoRuns2["metalUEFI"] = {
-            def id = marker == "" ? "kola-testiso-uefi" : "kola-testiso-uefi-${marker}"
-            ids += id
-            shwrap("mkdir -p ${outputDir}/${id}")
-            shwrap("cd ${cosaDir} && kola testiso -S --qemu-firmware=uefi ${extraArgsUEFI} --scenarios ${scenariosUEFI} --output-dir ${outputDir}/${id}/insecure")
-            shwrap("cd ${cosaDir} && kola testiso -S --qemu-firmware=uefi-secure ${extraArgsUEFI} --scenarios ${scenariosUEFI} --output-dir ${outputDir}/${id}/secure")
+        // only aarch64 and x86_64 support UEFI. aarch64 UEFI was
+        // already tested in the basic run above and secureboot isn't
+        // supported in aarch64 so we limit this to x86_64 for now.
+        // https://pagure.io/fedora-infrastructure/issue/7361
+        // https://github.com/coreos/coreos-assembler/blob/93efb63dcbd63dc04a782e2c6c617ae0cd4a51c8/mantle/platform/qemu.go#L1156
+        if (arch == 'x86_64') {
+            testIsoRuns2["metalUEFI"] = {
+                def id = marker == "" ? "kola-testiso-uefi" : "kola-testiso-uefi-${marker}"
+                ids += id
+                shwrap("cosa shell -- mkdir -p ${outputDir}/${id}")
+                shwrap("cosa kola testiso -S --qemu-firmware=uefi ${extraArgsUEFI} --scenarios ${scenariosUEFI} --output-dir ${outputDir}/${id}/insecure")
+                shwrap("cosa kola testiso -S --qemu-firmware=uefi-secure ${extraArgsUEFI} --scenarios ${scenariosUEFI} --output-dir ${outputDir}/${id}/secure")
+            }
         }
     }
 
     stage("Test Live Images") {
-        try {
-            parallel(testIsoRuns1)
-            parallel(testIsoRuns2)
-        } finally {
-            for (id in ids) {
-                shwrap("tar -c -C ${outputDir} ${id} | xz -c9 > ${env.WORKSPACE}/${id}-${token}.tar.xz")
-                archiveArtifacts allowEmptyArchive: true, artifacts: "${id}-${token}.tar.xz"
+        dir(cosaDir) {
+            try {
+                parallel(testIsoRuns1)
+                parallel(testIsoRuns2)
+            } finally {
+                for (id in ids) {
+                    shwrap("cosa shell -- tar -c --xz ${outputDir}/${id} > ${env.WORKSPACE}/${id}-${token}.tar.xz")
+                    archiveArtifacts allowEmptyArchive: true, artifacts: "${id}-${token}.tar.xz"
+                }
             }
         }
     }

--- a/vars/kolaTestIso.groovy
+++ b/vars/kolaTestIso.groovy
@@ -84,16 +84,15 @@ def call(params = [:]) {
         }
     }
 
-    stage("Test Live Images") {
-        dir(cosaDir) {
-            try {
-                parallel(testIsoRuns1)
-                parallel(testIsoRuns2)
-            } finally {
-                for (id in ids) {
-                    shwrap("cosa shell -- tar -c --xz ${outputDir}/${id} > ${env.WORKSPACE}/${id}-${token}.tar.xz")
-                    archiveArtifacts allowEmptyArchive: true, artifacts: "${id}-${token}.tar.xz"
-                }
+    // Run the Kola tests from the cosaDir
+    dir(cosaDir) {
+        try {
+            parallel(testIsoRuns1)
+            parallel(testIsoRuns2)
+        } finally {
+            for (id in ids) {
+                shwrap("cosa shell -- tar -c --xz ${outputDir}/${id} > ${env.WORKSPACE}/${id}-${token}.tar.xz")
+                archiveArtifacts allowEmptyArchive: true, artifacts: "${id}-${token}.tar.xz"
             }
         }
     }


### PR DESCRIPTION
```
commit 3c2aef4d73a320965c4628e29ec1780b31031ef3
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Thu Oct 13 11:37:31 2022 -0400

    {kola,kolaTestIso}: make the collection of logs non-fatal
    
    In case a test blew up for another reason let's not make the collection
    of the logs tank the entire run.

commit fd6649aae6df02b3402ed7760b48a1abc32d6458
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Thu Oct 13 11:34:56 2022 -0400

    {kola,kolaTestIso}: remove the unnecessary stage declaration
    
    When nesting `parallel` calls like we do in the `bump-lockfile` job
    in our FCOS pipeline the extra stage declaration confuses the Blue
    Ocean view. Let's just drop it.

commit c16b3d04ee98998a6367ab89143c13d3b6dfd15f
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Thu Oct 13 00:43:26 2022 -0400

    {kola,kolaTestIso}: make the parallel run names more meaningful
    
    In the bump-lockfile job in the pipeline we run all the architecture
    tests together so it helps to have the architecture in the name too.

commit b016e4cb11a5904389243abff067163d825b19a3
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Thu Oct 13 00:36:18 2022 -0400

    kola: add allowUpgradeFail argument
    
    This commit adds the ability to warn rather than error if upgrades fail.

commit 26f727e3b797fcf8f9995a6d23ce82c25aea2bbc
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Wed Oct 12 23:45:31 2022 -0400

    kola: simplify tests on non-QEMU or if user passed extraArgs
    
    We only need to worry about basic-qemu-scenarios and running reprovision
    tests separately when the platform is QEMU (the default). Loosely detect
    if the target platform is something other than QEMU by checking to see
    if the user provided platformArgs and if we are running against non-QEMU
    then just run all the tests up front and not in separate runs.
    
    Similarly if the user passed in `extraArgs` let's assume they want greater
    control and could be passing arguments that conflict with our `--tag`
    specifications in the invocations below. Given this assumption it would
    be better to just run the extraArgs in a single invocation up front.

commit 11d5fc68a0a157753c5389fa9b6a563f86ec24ac
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Wed Oct 12 23:32:29 2022 -0400

    {kola,kolaTestIso}: initial stab at multi-arch support
    
    The rule here is mostly to run things through either `cosa` commands
    or run generic bash commands through `cosa shell --`. This also is
    made easier if we're running the `cosa` command within `shwrap()`
    from the cosa dir already, so let's use `dir(cosaDir)` to try to
    enable that simplification.

commit c476a7c13a1554fee1961f4ffe2ad268da2c2164
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Wed Oct 12 15:44:21 2022 -0400

    {kola,kolaTestIso}: reduce number of try/finally blocks
    
    This makes the finally block (the log collection) more generic and
    allows for it to run at the end so that we can reduce the number of
    scopes in our code.

commit 8ef1d987c43b52b1bea2cbc6225a2c25681983da
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Wed Oct 12 15:19:18 2022 -0400

    kola: don't run basic tests again
    
    They already ran above in the --basic-qemu-scenarios invocation.
    
    This is similar to https://github.com/coreos/fedora-coreos-pipeline/commit/710be69

commit 05b64f072e390cea30711fac7da5c54824d17eb8
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Wed Oct 12 12:22:09 2022 -0400

    kolaTestIso: port over some changes from kola.groovy
    
    This mostly ports over 8804c62 and 042c0ba from kola.groovy
    which makes it so multiple runs can happen at the same time and
    also allows the caller to give a marker (some identifying info)
    about this run that will be stored in it's output filename. This
    makes it easier to find which archive to download in the Jenkins
    web UI.

commit f3bed2797f379845f495c0d9da29e822a82a629d
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Wed Oct 12 11:44:39 2022 -0400

    kolaTestIso: reduce conditional logic with scenariosArg var
    
    Reducing the branches makes it a little easier to read and understand
    what's going on.

```
