### PR TITLE
vars/utils: add compat symlink from `/srv/fcos` to `/srv/coreos`

### DIFF
--- a/vars/cosaBuild.groovy
+++ b/vars/cosaBuild.groovy
@@ -19,6 +19,14 @@ def call(params = [:]) {
 
         shwrap("mkdir -p ${cosaDir}")
 
+        // if the cosa dir is the default, also add a symlink from /srv/fcos
+        // for backwards compatibility
+        shwrap("""
+            if [ ${cosaDir} = /srv/coreos ]; then
+                ln -s coreos /srv/fcos
+            fi
+        """)
+
         if (!params['skipInit']) {
             def branchArg = ""
             if (params['gitBranch']) {


### PR DESCRIPTION
Commit 3719f69 ("tree: drop FCOS wording from various places") broke multiple upstream CI jobs which still reference the old location. We need to temporarily support both locations as we migrate them.

Add a compat symlink.