### PR TITLE
Delete compatibility symlinks for `fcos`-named things

### DIFF
--- a/vars/cosaBuild.groovy
+++ b/vars/cosaBuild.groovy
@@ -19,14 +19,6 @@ def call(params = [:]) {
 
         shwrap("mkdir -p ${cosaDir}")
 
-        // if the cosa dir is the default, also add a symlink from /srv/fcos
-        // for backwards compatibility
-        shwrap("""
-            if [ ${cosaDir} = /srv/coreos ]; then
-                ln -s coreos /srv/fcos
-            fi
-        """)
-
         if (!params['skipInit']) {
             def branchArg = ""
             if (params['gitBranch']) {

--- a/vars/fcosBuild.groovy
+++ b/vars/fcosBuild.groovy
@@ -1,1 +1,0 @@
-cosaBuild.groovy

--- a/vars/fcosKola.groovy
+++ b/vars/fcosKola.groovy
@@ -1,1 +1,0 @@
-kola.groovy

--- a/vars/fcosKolaTestIso.groovy
+++ b/vars/fcosKolaTestIso.groovy
@@ -1,1 +1,0 @@
-kolaTestIso.groovy


### PR DESCRIPTION
All the repos have been updated now, so we can drop the compat symlinks.