### PR TITLE
kola: run with parallel even if single stage

### DIFF
--- a/vars/kola.groovy
+++ b/vars/kola.groovy
@@ -129,11 +129,7 @@ def call(params = [:]) {
     }
 
     try {
-        if (kolaRuns.size() == 1) {
-            kolaRuns.each { k, v -> v() }
-        } else {
-            parallel(kolaRuns)
-        }
+        parallel(kolaRuns)
     } finally {
         for (id in ids) {
             // sanity check kola actually ran and dumped its output


### PR DESCRIPTION
I think with 380ffa5 it makes the optimization from 362e995 no longer required. In it's current form the kola-azure and kola-openstack tests in the pipeline don't have the kola tests broken out into a separate stage (they skip the upgrade test) so it's hard to find a failure in the blue ocean view when one happens.