### PR TITLE
utils: add some credential helpers

### DIFF
--- a/vars/utils.groovy
+++ b/vars/utils.groovy
@@ -34,3 +34,10 @@ def substituteStr(tmpl_str, bindings) {
     def tmpl = engine.createTemplate(tmpl_str).make(bindings)
     return tmpl.toString()
 }
+
+// Returns true if a credentials spec exists
+def credentialsExist(creds) {
+    def exists = false
+    tryWithCredentials(creds, { exists = true })
+    return exists
+}


### PR DESCRIPTION
```
commit 2adcb5a885485871bf388ead4a472cc499e34a2d
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Wed Oct 19 12:06:20 2022 -0400

    utils: add syncCredentialsIfInRemoteSession() helper
    
    This will help us copy over credentials to the remote node if we're
    inside a remote session. Having the code in a single place means we're
    less likely to copy/paste and make mistakes.

commit 6b18a7b4e794561019a3c9f76927e5db06b4730d
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Wed Oct 19 12:05:46 2022 -0400

    utils: add credentialsExist() helper

```
