### PR TITLE
{kola,kolaTestIso}: remove Arch from stage run titles by default

### DIFF
--- a/vars/kola.groovy
+++ b/vars/kola.groovy
@@ -19,7 +19,7 @@ def call(params = [:]) {
     def platformArgs = params.get('platformArgs', "");
     def buildID = params.get('build', "latest");
     def arch = params.get('arch', "x86_64");
-    def marker = params.get('marker', "kola");
+    def marker = params.get('marker', "");
     def rerun = "--rerun"
     if (params.get('disableRerun', false)) {
         rerun = ""

--- a/vars/kola.groovy
+++ b/vars/kola.groovy
@@ -36,12 +36,15 @@ def call(params = [:]) {
     // list of identifiers for each run for log collection
     def ids = []
 
+    // If given a marker then add it to the parallel run stage titles
+    def titleMarker = marker == "" ? "" : "${marker}:"
+
     // This is a bit obscure; what we're doing here is building a map of "name"
     // to "closure" which `parallel` will run in parallel. That way, we can
     // conditionally only add the `run_upgrades` stage if not explicitly
     // skipped.
     def kolaRuns = [:]
-    kolaRuns["${arch}:kola"] = {
+    kolaRuns["${titleMarker}kola"] = {
         def args = ""
         def id
         // Add the tests/kola directory, but only if it's not the same as the
@@ -108,7 +111,7 @@ def call(params = [:]) {
     }
 
     if (!params["skipUpgrade"]) {
-        kolaRuns["${arch}:kola:upgrade"] = {
+        kolaRuns["${titleMarker}kola:upgrade"] = {
             // If upgrades are broken `cosa kola --upgrades` might
             // fail to even find the previous image so we wrap this
             // in a try/catch so allowUpgradeFail can work.

--- a/vars/kolaTestIso.groovy
+++ b/vars/kolaTestIso.groovy
@@ -39,8 +39,11 @@ def call(params = [:]) {
     // list of identifiers for each run for log collection
     def ids = []
 
+    // If given a marker then add it to the parallel run stage titles
+    def titleMarker = marker == "" ? "" : "${marker}:"
+
     def testIsoRuns = [:]
-    testIsoRuns["${arch}:kola:metal"] = {
+    testIsoRuns["${titleMarker}kola:metal"] = {
         def id = marker == "" ? "kola-testiso-metal" : "kola-testiso-metal-${marker}"
         ids += id
         def scenariosArg = scenarios == "" ? "" : "--scenarios ${scenarios}"
@@ -51,7 +54,7 @@ def call(params = [:]) {
         // https://github.com/coreos/fedora-coreos-tracker/issues/1261
         // and testiso for s390x doesn't support iso installs either
         if (arch != 's390x') {
-            testIsoRuns["${arch}:kola:metal4k"] = {
+            testIsoRuns["${titleMarker}kola:metal4k"] = {
                 def id = marker == "" ? "kola-testiso-metal4k" : "kola-testiso-metal4k-${marker}"
                 ids += id
                 def scenariosArg = scenarios4k == "" ? "" : "--scenarios ${scenarios4k}"
@@ -60,7 +63,7 @@ def call(params = [:]) {
         }
     }
     if (!params['skipMultipath']) {
-        testIsoRuns["${arch}:kola:multipath"] = {
+        testIsoRuns["${titleMarker}kola:multipath"] = {
             def id = marker == "" ? "kola-testiso-multipath" : "kola-testiso-multipath-${marker}"
             ids += id
             shwrap("cd ${cosaDir} && cosa kola testiso -S --qemu-multipath ${extraArgsMultipath} --scenarios ${scenariosMultipath} --output-dir ${outputDir}/${id}")
@@ -73,7 +76,7 @@ def call(params = [:]) {
         // https://pagure.io/fedora-infrastructure/issue/7361
         // https://github.com/coreos/coreos-assembler/blob/93efb63dcbd63dc04a782e2c6c617ae0cd4a51c8/mantle/platform/qemu.go#L1156
         if (arch == 'x86_64') {
-            testIsoRuns["${arch}:kola:uefi"] = {
+            testIsoRuns["${titleMarker}kola:uefi"] = {
                 def id = marker == "" ? "kola-testiso-uefi" : "kola-testiso-uefi-${marker}"
                 ids += id
                 shwrap("cd ${cosaDir} && cosa shell -- mkdir -p ${outputDir}/${id}")


### PR DESCRIPTION
Including the arch everywhere is a bit overboard. Where it's really
needed is in our pipeline bump-lockfile job where we run tests from
all architectures at once. Everywhere else it's not really welcome.

Let's change the model a bit to include the marker given by the client
in the stage titles. Otherwise we won't add anything to them.
