### PR TITLE
kola/kolaTestIso: fix tar path

### DIFF
--- a/vars/kola.groovy
+++ b/vars/kola.groovy
@@ -138,7 +138,7 @@ def call(params = [:]) {
             // sanity check kola actually ran and dumped its output
             shwrap("cd ${cosaDir} && cosa shell -- test -d ${outputDir}/${id}")
             // collect the output
-            shwrap("cd ${cosaDir} && cosa shell -- tar -c --xz ${outputDir}/${id} > ${env.WORKSPACE}/${id}-${token}.tar.xz || :")
+            shwrap("cd ${cosaDir} && cosa shell -- tar -C ${outputDir} -c --xz ${id} > ${env.WORKSPACE}/${id}-${token}.tar.xz || :")
             archiveArtifacts allowEmptyArchive: true, artifacts: "${id}-${token}.tar.xz"
         }
     }

--- a/vars/kolaTestIso.groovy
+++ b/vars/kolaTestIso.groovy
@@ -92,7 +92,7 @@ def call(params = [:]) {
         utils.runParallel(testIsoRuns, 2)
     } finally {
         for (id in ids) {
-            shwrap("cd ${cosaDir} && cosa shell -- tar -c --xz ${outputDir}/${id} > ${env.WORKSPACE}/${id}-${token}.tar.xz || :")
+            shwrap("cd ${cosaDir} && cosa shell -- tar -C ${outputDir} -c --xz ${id} > ${env.WORKSPACE}/${id}-${token}.tar.xz || :")
             archiveArtifacts allowEmptyArchive: true, artifacts: "${id}-${token}.tar.xz"
         }
     }


### PR DESCRIPTION
If we pass the full directory name to `tar -c`, it'll want to recreate the whole structure on extracting. Instead, use `-C` so we only pass the final directory to `tar`. That'll ensure we still create at least one directory on extraction instead of filling up the working directory. We used to do this, but I think it got lost in the recent enhancements on these steps.