### PR TITLE
kola/kolaTestIso: support skipSecureBoot

### DIFF
--- a/vars/kola.groovy
+++ b/vars/kola.groovy
@@ -6,6 +6,7 @@
 //    cosaDir:           string   -- cosa working directory
 //    parallel:          integer  -- number of tests to run in parallel (default: # CPUs)
 //    skipBasicScenarios boolean  -- skip basic qemu scenarios
+//    skipSecureBoot     boolean  -- skip secureboot tests
 //    skipUpgrade:       boolean  -- skip running `cosa kola --upgrades`
 //    build:             string   -- cosa build ID to target
 //    platformArgs:      string   -- platform-specific kola args (e.g. '-p aws --aws-ami ...`)
@@ -96,7 +97,11 @@ def call(params = [:]) {
             if (!params['skipBasicScenarios']) {
                 id = marker == "" ? "kola-basic" : "kola-basic-${marker}"
                 ids += id
-                shwrap("cd ${cosaDir} && cosa kola run ${rerun} --output-dir=${outputDir}/${id} --basic-qemu-scenarios")
+                def skipSecureBootArg = ""
+                if (params['skipSecureBoot']) {
+                    skipSecureBootArg = "--skip-secure-boot"
+                }
+                shwrap("cd ${cosaDir} && cosa kola run ${rerun} --output-dir=${outputDir}/${id} --basic-qemu-scenarios ${skipSecureBootArg}")
             }
             // normal run (without reprovision tests because those require a lot of memory)
             id = marker == "" ? "kola" : "kola-${marker}"

--- a/vars/kolaTestIso.groovy
+++ b/vars/kolaTestIso.groovy
@@ -13,6 +13,7 @@
 //     skipMetal4k:        boolean -- skip metal4k image
 //     skipMultipath:      boolean -- skip multipath tests
 //     skipUEFI:           boolean -- skip UEFI tests
+//     skipSecureBoot      boolean -- skip secureboot tests
 //     marker:             string  -- some identifying text to add to uploaded artifact filenames
 def call(params = [:]) {
     def arch = params.get('arch', "x86_64");
@@ -81,7 +82,9 @@ def call(params = [:]) {
                 ids += id
                 shwrap("cd ${cosaDir} && cosa shell -- mkdir -p ${outputDir}/${id}")
                 shwrap("cd ${cosaDir} && cosa kola testiso -S --qemu-firmware=uefi ${extraArgsUEFI} --scenarios ${scenariosUEFI} --output-dir ${outputDir}/${id}/insecure")
-                shwrap("cd ${cosaDir} && cosa kola testiso -S --qemu-firmware=uefi-secure ${extraArgsUEFI} --scenarios ${scenariosUEFI} --output-dir ${outputDir}/${id}/secure")
+                if (!params['skipSecureBoot']) {
+                    shwrap("cd ${cosaDir} && cosa kola testiso -S --qemu-firmware=uefi-secure ${extraArgsUEFI} --scenarios ${scenariosUEFI} --output-dir ${outputDir}/${id}/secure")
+                }
             }
         }
     }


### PR DESCRIPTION
This will be used by the pipeline when SecureBoot tests should be skipped (e.g. when testing an unsigned kernel).