### PR TITLE
withPodmanRemote: add port 22 to CONTAINER_HOST env var

### DIFF
--- a/vars/withPodmanRemote.groovy
+++ b/vars/withPodmanRemote.groovy
@@ -14,7 +14,7 @@ def call(params = [:], Closure body) {
                           usernameVariable: 'REMOTEUSER',
                           keyFileVariable: 'CONTAINER_SSHKEY')
     ]) {
-        withEnv(["CONTAINER_HOST=ssh://${REMOTEUSER}@${REMOTEHOST}/run/user/${REMOTEUID}/podman/podman.sock"]) {
+        withEnv(["CONTAINER_HOST=ssh://${REMOTEUSER}@${REMOTEHOST}:22/run/user/${REMOTEUID}/podman/podman.sock"]) {
             shwrap("""
             # workaround bug: https://github.com/jenkinsci/configuration-as-code-plugin/issues/1646
             sed -i s/^----BEGIN/-----BEGIN/ \$CONTAINER_SSHKEY


### PR DESCRIPTION
There is a regression in podman [1] that causes podman remote sessions to not work unless the port is specified. Let's just add the port so we can get unblocked.

[1] https://github.com/containers/podman/issues/16509