### PR TITLE
kola: denylist rhcos.upgrade.from-ocp-rhcos for now

### DIFF
--- a/vars/kola.groovy
+++ b/vars/kola.groovy
@@ -106,7 +106,7 @@ def call(params = [:]) {
             // normal run (without reprovision tests because those require a lot of memory)
             id = marker == "" ? "kola" : "kola-${marker}"
             ids += id
-            shwrap("cd ${cosaDir} && cosa kola run ${rerun} --output-dir=${outputDir}/${id} --build=${buildID} ${archArg} ${platformArgs} --tag '!reprovision' --parallel ${parallel} ${args}")
+            shwrap("cd ${cosaDir} && cosa kola run ${rerun} --output-dir=${outputDir}/${id} --build=${buildID} ${archArg} ${platformArgs} --denylist-test rhcos.upgrade.from-ocp-rhcos --tag '!reprovision' --parallel ${parallel} ${args}")
 
             // re-provision tests (not run with --parallel argument to kola)
             id = marker == "" ? "kola-reprovision" : "kola-reprovision-${marker}"


### PR DESCRIPTION
This is a hack but we're in a time crunch and this is the fastest way to effect a change.

We'll revert this in the near future.