### PR TITLE
Add warn helper

### DIFF
--- a/vars/kola.groovy
+++ b/vars/kola.groovy
@@ -126,9 +126,7 @@ def call(params = [:]) {
                 shwrap("cd ${cosaDir} && cosa kola ${rerun} --output-dir=${outputDir}/${id} --upgrades --build=${buildID} ${archArg} ${platformArgs}")
             } catch(e) {
                 if (params["allowUpgradeFail"]) {
-                    warnError(message: 'Upgrade Failed') {
-                        error(e.getMessage())
-                    }
+                    warn(e.getMessage())
                 } else {
                     throw e
                 }

--- a/vars/warn.groovy
+++ b/vars/warn.groovy
@@ -1,0 +1,8 @@
+// Emits a warning and sets the build status as unstable. This is better than
+// just manually echoing and setting the build status, because the caught error
+// will better stand out in the BlueOcean view and logs.
+def call(msg) {
+    warnError(msg) {
+        error(msg)
+    }
+}


### PR DESCRIPTION
We started using this convention in a few places in the pipeline. Let's add a helper for it. Make it top-level so it feels as ergonomic as an `error` call.