### PR TITLE
Revert "kola: denylist rhcos.upgrade.from-ocp-rhcos for now"

### DIFF
--- a/vars/kola.groovy
+++ b/vars/kola.groovy
@@ -106,7 +106,7 @@ def call(params = [:]) {
             // normal run (without reprovision tests because those require a lot of memory)
             id = marker == "" ? "kola" : "kola-${marker}"
             ids += id
-            shwrap("cd ${cosaDir} && cosa kola run ${rerun} --output-dir=${outputDir}/${id} --build=${buildID} ${archArg} ${platformArgs} --denylist-test rhcos.upgrade.from-ocp-rhcos --tag '!reprovision' --parallel ${parallel} ${args}")
+            shwrap("cd ${cosaDir} && cosa kola run ${rerun} --output-dir=${outputDir}/${id} --build=${buildID} ${archArg} ${platformArgs} --tag '!reprovision' --parallel ${parallel} ${args}")
 
             // re-provision tests (not run with --parallel argument to kola)
             id = marker == "" ? "kola-reprovision" : "kola-reprovision-${marker}"


### PR DESCRIPTION
This reverts commit 06425433fb9d87f1467681f428a26c51164e3c12.

This test should be fixed now by
https://github.com/coreos/coreos-assembler/pull/3266 and backports.