### PR TITLE
buildImage: put tarball in directory itself

### DIFF
--- a/vars/buildImage.groovy
+++ b/vars/buildImage.groovy
@@ -47,14 +47,14 @@ def call(params = [:]) {
                 def jobMap  = job.object()
                 def uid     = jobMap.metadata.get('uid')
 
-                imageName = "coreos-ci-$repo-${UUID}"
+                imageName = "coreos-ci-$repo-${UUID}".toString()
 
                 //Create and unique name for image and bc
-                bcObj['parameters'][0] +=['name': 'NAME', 'value': "coreos-ci-$repo-${UUID}".toString()]
+                bcObj['parameters'][0] +=['name': 'NAME', 'value': imageName]
 
                 //Add OwnerReference for cascading deletion with the Job timeout
                 bcObj['parameters'][3] +=['name': 'UID', 'value': "${uid}".toString()]
-                bcObj['parameters'][2] +=['name': 'OWNERNAME', 'value': "coreos-ci-$repo-${UUID}".toString()]
+                bcObj['parameters'][2] +=['name': 'OWNERNAME', 'value': imageName]
                 if (params['dockerFile']) {
                     bcObj['parameters'][1] +=['name': 'DOCKERFILE', 'value': "${params['dockerFile']}".toString()]
                 }

--- a/vars/buildImage.groovy
+++ b/vars/buildImage.groovy
@@ -1,7 +1,6 @@
 // Builds a container image and returns its name.
 // Available parameters:
 //    dockerFile    string -- DockerFile used for the buildconfig
-//    workspace     string -- Path for local source dir used for `--from-dir=`
 //    env           dict -- Additional environment variables to set during build
 //    memory        amount of RAM to request
 //    cpu           amount of CPU to request
@@ -78,13 +77,11 @@ def call(params = [:]) {
                 openshift.create(openshift.process(bcObj))
             }
             stage('Build') {
-                def workspace = params.get('workspace', ".");
                 shwrap("""
-                    cd ${workspace}
                     touch dir.tar # pre-create it so the directory doesn't change when tar scans it
                     tar --exclude dir.tar --exclude=./pod* -zcf dir.tar .
                 """)
-                def build = openshift.selector('bc', imageName).startBuild("--from-archive=${workspace}/dir.tar")
+                def build = openshift.selector('bc', imageName).startBuild("--from-archive=dir.tar")
                 shwrap("rm dir.tar")
 
                 // Showing logs in Jenkins is also a way

--- a/vars/buildImage.groovy
+++ b/vars/buildImage.groovy
@@ -79,8 +79,13 @@ def call(params = [:]) {
             }
             stage('Build') {
                 def workspace = params.get('workspace', ".");
-                shwrap("tar --exclude=./pod* -zcf /tmp/dir.tar ${workspace}")
-                def build = openshift.selector('bc', imageName).startBuild("--from-archive=/tmp/dir.tar")
+                shwrap("""
+                    cd ${workspace}
+                    touch dir.tar # pre-create it so the directory doesn't change when tar scans it
+                    tar --exclude dir.tar --exclude=./pod* -zcf dir.tar .
+                """)
+                def build = openshift.selector('bc', imageName).startBuild("--from-archive=${workspace}/dir.tar")
+                shwrap("rm dir.tar")
 
                 // Showing logs in Jenkins is also a way
                 // to wait for the build to finsih


### PR DESCRIPTION
Currently, we're putting the tarball in `/tmp`, but if we're running on
the Jenkins controller, that's a semi-permanent shared location. Since
our generated tarball has a predictable name, we additionally run the
risk of racing with other `buildImage` calls on the controller and then
passing the wrong `dir.tar` to `oc start-build`.

Fix this by putting the tarball in the workspace itself. That way, it's
properly lifecycled to the job run, and there's no chance of racing with
other jobs.