### PR TITLE
Add `HOME` workaround to other shwrap helpers

### DIFF
--- a/vars/shwrapCapture.groovy
+++ b/vars/shwrapCapture.groovy
@@ -1,6 +1,8 @@
 def call(cmds) {
-    return sh(returnStdout: true, script: """
-        set -euo pipefail
-        ${cmds}
-    """).trim()
+    withEnv(["HOME=${env.WORKSPACE}"]) {
+        return sh(returnStdout: true, script: """
+            set -euo pipefail
+            ${cmds}
+        """).trim()
+    }
 }

--- a/vars/shwrapRc.groovy
+++ b/vars/shwrapRc.groovy
@@ -1,6 +1,8 @@
 def call(cmds) {
-    return sh(returnStatus: true, script: """
-        set -xeuo pipefail
-        ${cmds}
-    """)
+    withEnv(["HOME=${env.WORKSPACE}"]) {
+        return sh(returnStatus: true, script: """
+            set -xeuo pipefail
+            ${cmds}
+        """)
+    }
 }


### PR DESCRIPTION
We had it in `shwrap`, but not `shwrapCapture` and `shwrapRc`. We're hitting an issue right now where `podman` wants to create `$HOME/.ssh` when using the remote stuff but because we're running unprivileged, we get

```
Error: failed to connect: ssh: handshake failed: mkdir /.ssh: permission denied
```

We're still trying to determine why this is new, but let's fix the inconsistency for now.