### PR TITLE
Revert "Set `HOME` at the pod level instead of in shwrap helpers"

### DIFF
--- a/vars/pod.groovy
+++ b/vars/pod.groovy
@@ -30,10 +30,6 @@ def call(params = [:], Closure body) {
     podObj['spec']['containers'][0]['env'] = []
     podObj['spec']['containers'][0]['resources'] = [requests: [:], limits: [:]]
 
-    // HOME may not be set or set to /, which normally we don't have access to.
-    // Make sure it's set to a path we have access to.
-     podObj['spec']['containers'][0]['env'] += ['name': 'HOME', 'value': env.WORKSPACE]
-
     if (params['memory']) {
         podObj['spec']['containers'][0]['resources']['requests']['memory'] = params['memory'].toString()
         podObj['spec']['containers'][0]['resources']['limits']['memory'] = params['memory'].toString()

--- a/vars/shwrap.groovy
+++ b/vars/shwrap.groovy
@@ -1,10 +1,13 @@
 def call(cmds) {
-    // If umask is somehow unset, fix it.
-    sh """
-        set -xeuo pipefail
-        if [ `umask` = 0000 ]; then
-          umask 0022
-        fi
-        ${cmds}
-    """
+    // default is HOME=/ which normally we don't have access to.
+    // Also if umask is somehow unset, fix it.
+    withEnv(["HOME=${env.WORKSPACE}"]) {
+        sh """
+            set -xeuo pipefail
+            if [ `umask` = 0000 ]; then
+              umask 0022
+            fi
+            ${cmds}
+        """
+    }
 }

--- a/vars/shwrapCapture.groovy
+++ b/vars/shwrapCapture.groovy
@@ -1,10 +1,13 @@
 def call(cmds) {
-    // If umask is somehow unset, fix it.
-    return sh(returnStdout: true, script: """
-        set -euo pipefail
-        if [ `umask` = 0000 ]; then
-          umask 0022
-        fi
-        ${cmds}
-    """).trim()
+    // default is HOME=/ which normally we don't have access to.
+    // Also if umask is somehow unset, fix it.
+    withEnv(["HOME=${env.WORKSPACE}"]) {
+        return sh(returnStdout: true, script: """
+            set -euo pipefail
+            if [ `umask` = 0000 ]; then
+              umask 0022
+            fi
+            ${cmds}
+        """).trim()
+    }
 }

--- a/vars/shwrapRc.groovy
+++ b/vars/shwrapRc.groovy
@@ -1,10 +1,13 @@
 def call(cmds) {
-    // If umask is somehow unset, fix it.
-    return sh(returnStatus: true, script: """
-        set -xeuo pipefail
-        if [ `umask` = 0000 ]; then
-          umask 0022
-        fi
-        ${cmds}
-    """)
+    // default is HOME=/ which normally we don't have access to.
+    // Also if umask is somehow unset, fix it.
+    withEnv(["HOME=${env.WORKSPACE}"]) {
+        return sh(returnStatus: true, script: """
+            set -xeuo pipefail
+            if [ `umask` = 0000 ]; then
+              umask 0022
+            fi
+            ${cmds}
+        """)
+    }
 }


### PR DESCRIPTION
This reverts commit 3577892a9cac46964a5f44be8881a9ef7741df8c.

Setting the `HOME` var to the workspace from the pod definition doesn't work because it introduces a chicken-and-egg problem: the workspace isn't yet allocated since the pod isn't running yet.

This isn't a pure revert since I wanted to keep 33d4910 ("Add `umask` workaround to other shwrap helpers"), which came after.