### PR TITLE
kola: don't use whitespace in --allow-rerun-success option

### DIFF
--- a/vars/kola.groovy
+++ b/vars/kola.groovy
@@ -29,7 +29,7 @@ def call(params = [:]) {
         if (!params.get('disableRerunSuccess', false)) {
             // by default we'll allow rerun success for tests that need internet, but this can be overridden
             // by passing in a value to allowRerunSuccessArgs
-            rerun += " --allow-rerun-success "
+            rerun += " --allow-rerun-success="
             rerun += params.get('rerunSuccessArgs', "tags=needs-internet")
         }
     }


### PR DESCRIPTION
If we have a whitespace the parsing needle that we have to thread thread through cmd-kola into `kola run-upgrade` doesn't work right. We end up with:

```
[dustymabe@media fcos]$ cosa kola --rerun --allow-rerun-success tags=all --upgrades
kola -p qemu-unpriv tags=all --rerun --allow-rerun-success --output-dir tmp/kola-upgrade --qemu-image-dir tmp/kola-qemu-cache -v --find-parent-image
Error: unknown command "tags=all" for "kola"
Run 'kola --help' for usage.
2023-05-05 21:03:38.033149 C | cli: unknown command "tags=all" for "kola"
error: failed to execute cmd-kola: exit status 1
```