### PR TITLE
kola: specify action to runKola helper

### DIFF
--- a/vars/kola.groovy
+++ b/vars/kola.groovy
@@ -99,7 +99,7 @@ def call(params = [:]) {
         def addExtTests = params.get('addExtTests', [])
 
         for (path in addExtTests) {
-            args += " --exttest ${env.WORKSPACE}/${path}"
+            args += " --exttest=${env.WORKSPACE}/${path}"
         }
 
         if (platformArgs != "" || extraArgs != "") {
@@ -114,7 +114,7 @@ def call(params = [:]) {
             //      do a single run in that case.
             id = marker == "" ? "kola" : "kola-${marker}"
             ids += id
-            runKola(id, 'run', "--parallel ${parallel} ${args} ${extraArgs}")
+            runKola(id, 'run', "--parallel=${parallel} ${args} ${extraArgs}")
         } else {
             // basic run
             if (!params['skipBasicScenarios']) {
@@ -129,12 +129,12 @@ def call(params = [:]) {
             // normal run (without reprovision tests because those require a lot of memory)
             id = marker == "" ? "kola" : "kola-${marker}"
             ids += id
-            runKola(id, 'run', "--tag '!reprovision' --parallel ${parallel} ${args}")
+            runKola(id, 'run', "--tag='!reprovision' --parallel=${parallel} ${args}")
 
             // re-provision tests (not run with --parallel argument to kola)
             id = marker == "" ? "kola-reprovision" : "kola-reprovision-${marker}"
             ids += id
-            runKola(id, 'run', "--tag reprovision ${args}")
+            runKola(id, 'run', "--tag='reprovision' ${args}")
         }
     }
 


### PR DESCRIPTION
Right now in the upgrade case we end up with `cosa kola run --upgrades`
and that doesn't quite pass through everything right:

```
+ cosa kola run --rerun --allow-rerun-success=tags=needs-internet --build=39.20230823.92.0 --output-dir=/home/jenkins/agent/workspace/kola-gcp/tmp/kola-UJ7JH/kola-upgrade --on-warn-failure-exit-77 --arch=x86_64 -p=gcp --gcp-json-key=**** --gcp-project=fedora-coreos-testing --upgrades

kola --build 39.20230823.92.0 run --rerun --allow-rerun-success=tags=needs-internet --on-warn-failure-exit-77 --arch=x86_64 -p=gcp --gcp-json-key=**** --gcp-project=fedora-coreos-testing --output-dir /home/jenkins/agent/workspace/kola-gcp/tmp/kola-UJ7JH/kola-upgrade --qemu-image-dir tmp/kola-qemu-cache -v --find-parent-image

Error: unknown flag: --qemu-image-dir
```

We need the ultimate command to be `kola run-upgrade`. Let's add the
action we want as an argument to the runKola helper.