### PR TITLE
job.yaml: fix apiVersion and other tweaks

### DIFF
--- a/resources/com/github/coreos/job.yaml
+++ b/resources/com/github/coreos/job.yaml
@@ -3,9 +3,11 @@
 # here isn't used for anything (other than staying alive for 24h).
 
 kind: Template
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 metadata:
-  name: clean-up
+  # the name doesn't matter since we don't actually create a template object
+  # from this; we just instantiate from it client-side
+  name: unused
 objects:
 - apiVersion: batch/v1
   kind: Job
@@ -25,4 +27,3 @@ objects:
 parameters:
 - name: NAME
   required: true
-  value: cleanupJob


### PR DESCRIPTION
The API version for templates is now `template.openshift.io/v1`. Possibly `v1` was accepted before but not anymore? Fix it.

While we're here, tweak the template name to make it clearer that the template itself is never created as an object.

Also remove the parameter default value to hard require clients to always specify it.