### PR TITLE
kola/kolaTestIso: use `kola-junit` to publish JUnit test results

### DIFF
--- a/vars/kola.groovy
+++ b/vars/kola.groovy
@@ -170,6 +170,14 @@ def call(params = [:]) {
             // collect the output
             shwrap("cd ${cosaDir} && cosa shell -- tar -C ${outputDir} -c --xz ${id} > ${env.WORKSPACE}/${id}-${token}.tar.xz || :")
             archiveArtifacts allowEmptyArchive: true, artifacts: "${id}-${token}.tar.xz"
+            // skip junit output for basic, which isn't native to kola so has
+            // a different layout; we can drop this once
+            // https://github.com/coreos/coreos-assembler/pull/3652 merges
+            if (id.contains('basic')) {
+                continue
+            }
+            shwrap("cd ${cosaDir} && cosa shell -- /usr/lib/coreos-assembler/kola-junit --classname ${id} --koladir ${outputDir}/${id} --output - > ${env.WORKSPACE}/${id}-${token}.xml || :")
+            junit allowEmptyResults: true, skipMarkingBuildUnstable: true, skipPublishingChecks: true, testResults: "${id}-${token}.xml"
         }
     }
 }

--- a/vars/kolaTestIso.groovy
+++ b/vars/kolaTestIso.groovy
@@ -25,7 +25,7 @@ def call(params = [:]) {
     // Create a unique output directory for this run of kola
     def outputDir = shwrapCapture("cd ${cosaDir} && cosa shell -- mktemp -d ${cosaDir}/tmp/kola-XXXXX")
 
-    def id = marker == "" ? "kolatestiso" : "kolatestiso-${marker}"
+    def id = marker == "" ? "kola-testiso" : "kola-testiso-${marker}"
 
     // We add --inst-insecure here since in CI and in our build pipeline
     // the signatures for the metal images won't have been created yet.
@@ -34,5 +34,7 @@ def call(params = [:]) {
     } finally {
         shwrap("cd ${cosaDir} && cosa shell -- tar -C ${outputDir} -c --xz ${id} > ${env.WORKSPACE}/${id}-${token}.tar.xz || :")
         archiveArtifacts allowEmptyArchive: true, artifacts: "${id}-${token}.tar.xz"
+        shwrap("cd ${cosaDir} && cosa shell -- /usr/lib/coreos-assembler/kola-junit --classname ${id} --koladir ${outputDir}/${id} --output - > ${env.WORKSPACE}/${id}-${token}.xml || :")
+        junit allowEmptyResults: true, skipMarkingBuildUnstable: true, skipPublishingChecks: true, testResults: "${id}-${token}.xml"
     }
 }


### PR DESCRIPTION
This will allow us to much more easily inspect failing kola tests. Goes together with https://github.com/coreos/coreos-assembler/pull/3667, which has more details.

While we're here, use `kola-testiso` as marker since it looks clearer and for consistency with `kola-upgrade`.