### PR TITLE
vars/checkoutToDir: fix checkout step syntax

### DIFF
--- a/vars/checkoutToDir.groovy
+++ b/vars/checkoutToDir.groovy
@@ -3,7 +3,7 @@ def call(scm, dir) {
     checkout([
          $class: 'GitSCM',
          branches: scm.branches,
-         extensions: scm.extensions + [[$class: 'RelativeTargetDirectory', relativeTargetDir: dir, recursiveSubmodules: true]],
+         extensions: scm.extensions + [submodule(recursiveSubmodules: true), [$class: 'RelativeTargetDirectory', relativeTargetDir: dir]],
          userRemoteConfigs: scm.userRemoteConfigs
     ])
 }


### PR DESCRIPTION
The extensions object's syntax here is incorrect:

> WARNING: Unknown parameter(s) found for class type 'hudson.plugins.git.extensions.impl.RelativeTargetDirectory': recursiveSubmodules

The `recursiveSubmodules` option is part of another extension type we need to add to the list.