### PR TITLE
kolaTestIso: retry failed tests

### DIFF
--- a/vars/withPodmanRemote.groovy
+++ b/vars/withPodmanRemote.groovy
@@ -2,19 +2,16 @@
 // environment variables CONTAINER_SSHKEY and CONTAINER_HOST
 // Available parameters:
 //    remoteHost:    string -- Credential ID containing the remote host
-//    remoteUid:     string -- Credential ID containing the remote user UID
 //    sshKey:        string -- Credential ID containing the private SSH key
 def call(params = [:], Closure body) {
     withCredentials([
         string(credentialsId: params['remoteHost'],
                variable: 'REMOTEHOST'),
-        string(credentialsId: params['remoteUid'],
-               variable: 'REMOTEUID'),
         sshUserPrivateKey(credentialsId: params['sshKey'],
                           usernameVariable: 'REMOTEUSER',
                           keyFileVariable: 'CONTAINER_SSHKEY')
     ]) {
-        withEnv(["CONTAINER_HOST=ssh://${REMOTEUSER}@${REMOTEHOST}:22/run/user/${REMOTEUID}/podman/podman.sock"]) {
+        withEnv(["CONTAINER_HOST=ssh://${REMOTEUSER}@${REMOTEHOST}"]) {
             shwrap("""
             # workaround bug: https://github.com/jenkinsci/configuration-as-code-plugin/issues/1646
             sed -i s/^----BEGIN/-----BEGIN/ \$CONTAINER_SSHKEY


### PR DESCRIPTION
We've been seeing a lot of testiso flakes lately. Let's try to give ourselves a break by retrying like we do for normal kola runs.

This is slightly different because it's not done inside kola but outside kola. For the inside kola retry of testiso we'll wait for https://github.com/coreos/coreos-assembler/issues/3989 to happen.