### PR TITLE
kolaTestIso: Retry all testiso failures

### DIFF
--- a/vars/kolaTestIso.groovy
+++ b/vars/kolaTestIso.groovy
@@ -37,10 +37,11 @@ def call(params = [:]) {
             def rerun_tests = shwrapCapture("""
                 cd ${cosaDir}
                 cosa shell -- cat ${outputDir}/${id}/reports/report.json | \
-                    jq -r '.tests[] | select(.result == "FAIL") | .name'
+                    jq -r '.tests[] | select(.result == "FAIL") | .name' | \
+                    tr '\n' ' '
             """)
             echo "Re-running failed tests (flake detection): ${rerun_tests}"
-            shwrap("cd ${cosaDir} && cosa kola testiso --inst-insecure ${rerun_tests} --output-dir ${outputDir}/${id}/rerun")
+            shwrap("cd ${cosaDir} && cosa kola testiso --inst-insecure --output-dir ${outputDir}/${id}/rerun ${rerun_tests}")
         } else {
             throw e
         }


### PR DESCRIPTION
Fixes b1f6e8a. If there are multiple test failures the newline in the output will mean only one test failure gets retried. This also means that the outputdir wasn't getting set right. Removing just the newline should fix both issues, but let's move the `--output-dir` option earlier in the command invocation anyway.