### PR TITLE
cosaPod: archive cosa git info and RPMs

### DIFF
--- a/vars/cosaPod.groovy
+++ b/vars/cosaPod.groovy
@@ -15,7 +15,11 @@ def call(params = [:], Closure body) {
     params['cmd'] = ["/usr/bin/dumb-init", "/usr/bin/sleep", "infinity"]
 
     pod(params) {
-        shwrap("cat /cosa/coreos-assembler-git.json || :")
+        shwrap("(cat /cosa/coreos-assembler-git.json || :) | tee coreos-assembler-git.json")
+        archiveArtifacts artifacts: "coreos-assembler-git.json"
+        shwrap("rpm -qa | sort > coreos-assembler-rpmdb.txt")
+        archiveArtifacts artifacts: "coreos-assembler-rpmdb.txt"
+        shwrap("rm coreos-assembler-git.json coreos-assembler-rpmdb.txt")
         body()
     }
 }


### PR DESCRIPTION
The git info is already printed but having it be a proper archive makes it easier to access.

Also archive the full rpmdb package list.