### PR TITLE
cosaBuild: call `cosa osbuild` separately

### DIFF
--- a/vars/cosaBuild.groovy
+++ b/vars/cosaBuild.groovy
@@ -60,6 +60,7 @@ def call(params = [:]) {
 
         shwrap("cd ${cosaDir} && cosa fetch ${extraFetchArgs}")
         shwrap("cd ${cosaDir} && cosa build ${extraArgs}")
+        shwrap("cd ${cosaDir} && cosa osbuild qemu")
     }
 
     if (!params['skipKola']) {


### PR DESCRIPTION
In https://github.com/coreos/coreos-assembler/pull/4255 we are proposing to remove followup target build support from `cosa build`; i.e. it won't auto build the `qemu` target when doing a build.

Let's split this part out into a separate step here.