### PR TITLE
kolaTestIso: check for testiso command before running tests

### DIFF
--- a/vars/kolaTestIso.groovy
+++ b/vars/kolaTestIso.groovy
@@ -11,6 +11,11 @@ def call(params = [:]) {
     def extraArgs = params.get('extraArgs', "");
     def marker = params.get('marker', "");
 
+    // Check if kola has testiso command, skip if not available
+    if (shwrapRc("cosa kola help | grep -q testiso") != 0) {
+        echo "Skipping kola testiso: command not available in this version of kola"
+        return
+    }
 
     if (params['skipUEFI']) {
         extraArgs += " --denylist-test *.uefi*"


### PR DESCRIPTION
Part of folding `testiso` into `kola run`.

Issue: https://github.com/coreos/coreos-assembler/issues/3989

Related:
https://github.com/coreos/coreos-assembler/pull/4377
https://github.com/coreos/fedora-coreos-pipeline/pull/1339
