### PR TITLE
kola: add --inst-insecure flag to kola tests

### DIFF
--- a/vars/kola.groovy
+++ b/vars/kola.groovy
@@ -109,6 +109,11 @@ def call(params = [:]) {
             args += " --tag=!${tag}"
         }
 
+        // add insecure flag for iso tests
+        if (shwrapRc("cosa kola help | grep -q testiso") != 0) {
+            args += " --inst-insecure"
+        }
+
         if (platformArgs != "" || extraArgs != "") {
             // There are two cases where we land here:
             //   1. The user passed `platformArgs`, which implies we're


### PR DESCRIPTION
Autodetection of dev builds fails on builds where 'dev' is not part of the filename scheme, like `rhcos-9.8.20260506-0-live-iso.x86_64.iso`. This causes kola tests to fail when they should run in insecure mode.

The obsolete `vars/kolaTestIso.groovy` used the insecure flag by default, so this restores that behavior explicitly.