### PR TITLE
cosaPod: add timeout to prevent pods from running indefinitely

### DIFF
--- a/vars/cosaPod.groovy
+++ b/vars/cosaPod.groovy
@@ -1,6 +1,7 @@
 // Thin wrapper around pod() which auto-selects images and kvm.
 // Additional available parameters:
 //   image: string
+//   timeout: int (hours, default: 24, 0 to disable)
 def call(params = [:], Closure body) {
     if (params['image'] == null) {
         params['image'] = 'quay.io/coreos-assembler/coreos-assembler:main'
@@ -11,15 +12,26 @@ def call(params = [:], Closure body) {
         params['kvm'] = true
     }
 
+    def podTimeout = params.containsKey('timeout') ? params.remove('timeout') : 24
+
     // we don't like zombies
     params['cmd'] = ["/usr/bin/dumb-init", "/usr/bin/sleep", "infinity"]
 
     pod(params) {
-        shwrap("(cat /cosa/coreos-assembler-git.json || :) | tee coreos-assembler-git.json")
-        archiveArtifacts artifacts: "coreos-assembler-git.json"
-        shwrap("rpm -qa | sort > coreos-assembler-rpmdb.txt")
-        archiveArtifacts artifacts: "coreos-assembler-rpmdb.txt"
-        shwrap("rm coreos-assembler-git.json coreos-assembler-rpmdb.txt")
-        body()
+        def runBody = {
+            shwrap("(cat /cosa/coreos-assembler-git.json || :) | tee coreos-assembler-git.json")
+            archiveArtifacts artifacts: "coreos-assembler-git.json"
+            shwrap("rpm -qa | sort > coreos-assembler-rpmdb.txt")
+            archiveArtifacts artifacts: "coreos-assembler-rpmdb.txt"
+            shwrap("rm coreos-assembler-git.json coreos-assembler-rpmdb.txt")
+            body()
+        }
+        if (podTimeout > 0) {
+            timeout(time: podTimeout, unit: 'HOURS') {
+                runBody()
+            }
+        } else {
+            runBody()
+        }
     }
 }


### PR DESCRIPTION
## Summary

- Adds a `timeout` parameter to `cosaPod` (default: 24 hours) to prevent hung or failed pods from blocking the pipeline indefinitely
- Callers can override the timeout (in hours) or disable it with `timeout: 0` for jobs like debug pods that need extended runtime
- Uses Jenkins' built-in `timeout` step which gracefully aborts the build on expiry

Fixes: https://github.com/coreos/fedora-coreos-pipeline/issues/1296
