### PR TITLE
kola: make testiso command detection more verbose

### DIFF
--- a/vars/kola.groovy
+++ b/vars/kola.groovy
@@ -109,8 +109,8 @@ def call(params = [:]) {
             args += " --tag=!${tag}"
         }
 
-        // add insecure flag for iso tests
-        if (shwrapRc("cosa kola help | grep -q testiso") != 0) {
+        if (!utils.isTestisoSupported()) {
+            echo "Adding --inst-insecure for live tests since kola doesn't support the testiso command"
             args += " --inst-insecure"
         }
 

--- a/vars/kolaTestIso.groovy
+++ b/vars/kolaTestIso.groovy
@@ -11,9 +11,8 @@ def call(params = [:]) {
     def extraArgs = params.get('extraArgs', "");
     def marker = params.get('marker', "");
 
-    // Check if kola has testiso command, skip if not available
-    if (shwrapRc("cosa kola help | grep -q testiso") != 0) {
-        echo "Skipping kola testiso: command not available in this version of kola"
+    if (!utils.isTestisoSupported()) {
+        echo "Skipping 'kola testiso': command not available in this version of kola"
         return
     }
 

--- a/vars/utils.groovy
+++ b/vars/utils.groovy
@@ -83,3 +83,12 @@ def syncCredentialsIfInRemoteSession(envvars) {
         """)
     }
 }
+
+def isTestisoSupported() {
+    try {
+        return shwrapCapture("cosa kola help").contains("testiso")
+    } catch (Exception e) {
+        echo("Exception occurred while checking testiso support: ${e.getMessage()}")
+        return false
+    }
+}


### PR DESCRIPTION
There is a strange issue where probably `shwrapRc("kola help | grep -q testiso")` returns a non-zero exit code despite the `testiso` command being available. As a result, we incorrectly fall back to the newer code path and hit failures like:
```
  06:19:32  Error: unknown flag: --inst-insecure
```